### PR TITLE
Bump version to v0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-signature-capture",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Lets users sign their signatures",
   "main": "SignatureCapture.js",
   "scripts": {


### PR DESCRIPTION
Feel like v0.4.1 is old version that installed from npm.
Should update npm version.
Please check this issue: https://github.com/RepairShopr/react-native-signature-capture/issues/25