### PR TITLE
Add iOS support for saveImage and resetImage calls

### DIFF
--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -65,7 +65,7 @@ class SignatureCapture extends React.Component {
 
     saveImage() {
         UIManager.dispatchViewManagerCommand(
-            React.findNodeHandle(this),
+            ReactNative.findNodeHandle(this),
             UIManager.RSSignatureView.Commands.saveImage,
             [],
         );
@@ -73,7 +73,7 @@ class SignatureCapture extends React.Component {
 
     resetImage() {
         UIManager.dispatchViewManagerCommand(
-            React.findNodeHandle(this),
+            ReactNative.findNodeHandle(this),
             UIManager.RSSignatureView.Commands.resetImage,
             [],
         );

--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -44,10 +44,19 @@ class SignatureCapture extends React.Component {
     }
 
     componentDidMount() {
-        this.subscription = DeviceEventEmitter.addListener(
-            'onSaveEvent',
-            this.props.onSaveEvent
-        );
+        if (this.props.onSaveEvent) {
+            this.subscription = DeviceEventEmitter.addListener(
+                'onSaveEvent',
+                this.props.onSaveEvent
+            );
+        }
+
+        if (this.props.onDragEvent) {
+            this.subscription = DeviceEventEmitter.addListener(
+                'onDragEvent',
+                this.props.onDragEvent
+            );
+        }
     }
 
     componentWillUnmount() {

--- a/ios/PPSSignatureView.h
+++ b/ios/PPSSignatureView.h
@@ -1,11 +1,14 @@
 #import <UIKit/UIKit.h>
 #import <GLKit/GLKit.h>
 
+@class RSSignatureViewManager;
+
 @interface PPSSignatureView : GLKView
 
 @property (assign, nonatomic) UIColor *strokeColor;
 @property (assign, nonatomic) BOOL hasSignature;
 @property (strong, nonatomic) UIImage *signatureImage;
+@property (nonatomic, strong) RSSignatureViewManager *manager;
 
 - (void)erase;
 

--- a/ios/PPSSignatureView.m
+++ b/ios/PPSSignatureView.m
@@ -1,5 +1,6 @@
 #import "PPSSignatureView.h"
 #import <OpenGLES/ES2/glext.h>
+#import "RSSignatureViewManager.h"
 
 #define             STROKE_WIDTH_MIN 0.004 // Stroke width determined by touch velocity
 #define             STROKE_WIDTH_MAX 0.030
@@ -201,7 +202,6 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, dotsLength);
 	}
 }
-
 
 - (void)erase {
 	length = 0;
@@ -414,6 +414,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 		addVertex(&length, previousVertex);
 		
 		self.hasSignature = YES;
+		[self.manager publishDraggedEvent];
 		
 	} else if ([p state] == UIGestureRecognizerStateChanged) {
 		

--- a/ios/RSSignatureView.h
+++ b/ios/RSSignatureView.h
@@ -10,4 +10,6 @@
 @property (nonatomic, strong) RSSignatureViewManager *manager;
 -(void) onSaveButtonPressed;
 -(void) onClearButtonPressed;
+-(void) saveImage;
+-(void) erase;
 @end

--- a/ios/RSSignatureView.m
+++ b/ios/RSSignatureView.m
@@ -60,6 +60,7 @@
 		sign = [[PPSSignatureView alloc]
 						initWithFrame: CGRectMake(0, 0, screen.width, screen.height)
 						context: _context];
+		sign.manager = manager;
 		
 		[self addSubview:sign];
 		

--- a/ios/RSSignatureView.m
+++ b/ios/RSSignatureView.m
@@ -16,6 +16,7 @@
 	UILabel *titleLabel;
 	BOOL _rotateClockwise;
 	BOOL _square;
+	BOOL _showNativeButtons;
 }
 
 @synthesize sign;
@@ -23,6 +24,7 @@
 
 - (instancetype)init
 {
+	_showNativeButtons = YES;
 	if ((self = [super init])) {
 		_border = [CAShapeLayer layer];
 		_border.strokeColor = [UIColor blackColor].CGColor;
@@ -73,31 +75,33 @@
 			//[titleLabel setBackgroundColor:[UIColor greenColor]];
 			[sign addSubview:titleLabel];
 			
-			//Save button
-			saveButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-			[saveButton setLineBreakMode:NSLineBreakByClipping];
-			[saveButton addTarget:self action:@selector(onSaveButtonPressed)
-					 forControlEvents:UIControlEventTouchUpInside];
-			[saveButton setTitle:@"Save" forState:UIControlStateNormal];
-			
-			CGSize buttonSize = CGSizeMake(80, 55.0);
-			
-			saveButton.frame = CGRectMake(sign.bounds.size.width - buttonSize.width,
-																		0, buttonSize.width, buttonSize.height);
-			[saveButton setBackgroundColor:[UIColor colorWithRed:250/255.f green:250/255.f blue:250/255.f alpha:1.f]];
-			[sign addSubview:saveButton];
-			
-			
-			//Clear button
-			clearButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-			[clearButton setLineBreakMode:NSLineBreakByClipping];
-			[clearButton addTarget:self action:@selector(onClearButtonPressed)
-						forControlEvents:UIControlEventTouchUpInside];
-			[clearButton setTitle:@"Reset" forState:UIControlStateNormal];
-			
-			clearButton.frame = CGRectMake(0, 0, buttonSize.width, buttonSize.height);
-			[clearButton setBackgroundColor:[UIColor colorWithRed:250/255.f green:250/255.f blue:250/255.f alpha:1.f]];
-			[sign addSubview:clearButton];
+			if (_showNativeButtons) {
+				//Save button
+				saveButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+				[saveButton setLineBreakMode:NSLineBreakByClipping];
+				[saveButton addTarget:self action:@selector(onSaveButtonPressed)
+				            forControlEvents:UIControlEventTouchUpInside];
+				[saveButton setTitle:@"Save" forState:UIControlStateNormal];
+
+				CGSize buttonSize = CGSizeMake(80, 55.0);
+
+				saveButton.frame = CGRectMake(sign.bounds.size.width - buttonSize.width,
+				                              0, buttonSize.width, buttonSize.height);
+				[saveButton setBackgroundColor:[UIColor colorWithRed:250/255.f green:250/255.f blue:250/255.f alpha:1.f]];
+				[sign addSubview:saveButton];
+
+
+				//Clear button
+				clearButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+				[clearButton setLineBreakMode:NSLineBreakByClipping];
+				[clearButton addTarget:self action:@selector(onClearButtonPressed)
+				             forControlEvents:UIControlEventTouchUpInside];
+				[clearButton setTitle:@"Reset" forState:UIControlStateNormal];
+
+				clearButton.frame = CGRectMake(0, 0, buttonSize.width, buttonSize.height);
+				[clearButton setBackgroundColor:[UIColor colorWithRed:250/255.f green:250/255.f blue:250/255.f alpha:1.f]];
+				[sign addSubview:clearButton];
+			}
 		}
 		else {
 			
@@ -111,31 +115,33 @@
 			//[titleLabel setBackgroundColor:[UIColor greenColor]];
 			[sign addSubview:titleLabel];
 			
-			//Save button
-			saveButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-			[saveButton setTransform:CGAffineTransformMakeRotation(DEGREES_TO_RADIANS(90))];
-			[saveButton setLineBreakMode:NSLineBreakByClipping];
-			[saveButton addTarget:self action:@selector(onSaveButtonPressed)
-      forControlEvents:UIControlEventTouchUpInside];
-			[saveButton setTitle:@"Save" forState:UIControlStateNormal];
-			
-			CGSize buttonSize = CGSizeMake(55, 80.0); //Width/Height is swapped
-			
-			saveButton.frame = CGRectMake(sign.bounds.size.width - buttonSize.width, sign.bounds.size.height - buttonSize.height, buttonSize.width, buttonSize.height);
-			[saveButton setBackgroundColor:[UIColor colorWithRed:250/255.f green:250/255.f blue:250/255.f alpha:1.f]];
-			[sign addSubview:saveButton];
-			
-			//Clear button
-			clearButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-			[clearButton setTransform:CGAffineTransformMakeRotation(DEGREES_TO_RADIANS(90))];
-			[clearButton setLineBreakMode:NSLineBreakByClipping];
-			[clearButton addTarget:self action:@selector(onClearButtonPressed)
-						forControlEvents:UIControlEventTouchUpInside];
-			[clearButton setTitle:@"Reset" forState:UIControlStateNormal];
-			
-			clearButton.frame = CGRectMake(sign.bounds.size.width - buttonSize.width, 0, buttonSize.width, buttonSize.height);
-			[clearButton setBackgroundColor:[UIColor colorWithRed:250/255.f green:250/255.f blue:250/255.f alpha:1.f]];
-			[sign addSubview:clearButton];
+			if (_showNativeButtons) {
+				//Save button
+				saveButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+				[saveButton setTransform:CGAffineTransformMakeRotation(DEGREES_TO_RADIANS(90))];
+				[saveButton setLineBreakMode:NSLineBreakByClipping];
+				[saveButton addTarget:self action:@selector(onSaveButtonPressed)
+				            forControlEvents:UIControlEventTouchUpInside];
+				[saveButton setTitle:@"Save" forState:UIControlStateNormal];
+
+				CGSize buttonSize = CGSizeMake(55, 80.0); //Width/Height is swapped
+
+				saveButton.frame = CGRectMake(sign.bounds.size.width - buttonSize.width, sign.bounds.size.height - buttonSize.height, buttonSize.width, buttonSize.height);
+				[saveButton setBackgroundColor:[UIColor colorWithRed:250/255.f green:250/255.f blue:250/255.f alpha:1.f]];
+				[sign addSubview:saveButton];
+
+				//Clear button
+				clearButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+				[clearButton setTransform:CGAffineTransformMakeRotation(DEGREES_TO_RADIANS(90))];
+				[clearButton setLineBreakMode:NSLineBreakByClipping];
+				[clearButton addTarget:self action:@selector(onClearButtonPressed)
+				             forControlEvents:UIControlEventTouchUpInside];
+				[clearButton setTitle:@"Reset" forState:UIControlStateNormal];
+
+				clearButton.frame = CGRectMake(sign.bounds.size.width - buttonSize.width, 0, buttonSize.width, buttonSize.height);
+				[clearButton setBackgroundColor:[UIColor colorWithRed:250/255.f green:250/255.f blue:250/255.f alpha:1.f]];
+				[sign addSubview:clearButton];
+			}
 		}
 		
 	}
@@ -152,7 +158,15 @@
 	_square = square;
 }
 
+- (void)setShowNativeButtons:(BOOL)showNativeButtons {
+	_showNativeButtons = showNativeButtons;
+}
+
 -(void) onSaveButtonPressed {
+	[self saveImage];
+}
+
+-(void) saveImage {
 	saveButton.hidden = YES;
 	clearButton.hidden = YES;
 	UIImage *signImage = [self.sign signatureImage: _rotateClockwise withSquare:_square];
@@ -183,11 +197,15 @@
 		//UInt32 result = [attrs fileSize];
 		
 		NSString *base64Encoded = [imageData base64EncodedStringWithOptions:0];
-		[self.manager saveImage: tempPath withEncoded:base64Encoded];
+		[self.manager publishSaveImageEvent: tempPath withEncoded:base64Encoded];
 	}
 }
 
 -(void) onClearButtonPressed {
+	[self erase];
+}
+
+-(void) erase {
 	[self.sign erase];
 }
 

--- a/ios/RSSignatureViewManager.h
+++ b/ios/RSSignatureViewManager.h
@@ -6,4 +6,5 @@
 -(void) saveImage:(nonnull NSNumber *)reactTag;
 -(void) resetImage:(nonnull NSNumber *)reactTag;
 -(void) publishSaveImageEvent:(NSString *) aTempPath withEncoded: (NSString *) aEncoded;
+-(void) publishDraggedEvent;
 @end

--- a/ios/RSSignatureViewManager.h
+++ b/ios/RSSignatureViewManager.h
@@ -3,5 +3,7 @@
 
 @interface RSSignatureViewManager : RCTViewManager
 @property (nonatomic, strong) RSSignatureView *signView;
--(void) saveImage:(NSString *) aTempPath withEncoded: (NSString *) aEncoded;
+-(void) saveImage:(nonnull NSNumber *)reactTag;
+-(void) resetImage:(nonnull NSNumber *)reactTag;
+-(void) publishSaveImageEvent:(NSString *) aTempPath withEncoded: (NSString *) aEncoded;
 @end

--- a/ios/RSSignatureViewManager.m
+++ b/ios/RSSignatureViewManager.m
@@ -12,6 +12,8 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(rotateClockwise, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(square, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(showNativeButtons, BOOL)
+
 
 -(dispatch_queue_t) methodQueue
 {
@@ -25,7 +27,21 @@ RCT_EXPORT_VIEW_PROPERTY(square, BOOL)
 	return signView;
 }
 
--(void) saveImage:(NSString *) aTempPath withEncoded: (NSString *) aEncoded {
+// Both of these methods needs to be called from the main thread so the
+// UI can clear out the signature.
+RCT_EXPORT_METHOD(saveImage:(nonnull NSNumber *)reactTag) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[self.signView saveImage];
+	});
+}
+
+RCT_EXPORT_METHOD(resetImage:(nonnull NSNumber *)reactTag) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[self.signView erase];
+	});
+}
+
+-(void) publishSaveImageEvent:(NSString *) aTempPath withEncoded: (NSString *) aEncoded {
 	[self.bridge.eventDispatcher
 	 sendDeviceEventWithName:@"onSaveEvent"
 	 body:@{

--- a/ios/RSSignatureViewManager.m
+++ b/ios/RSSignatureViewManager.m
@@ -50,4 +50,10 @@ RCT_EXPORT_METHOD(resetImage:(nonnull NSNumber *)reactTag) {
 					}];
 }
 
+-(void) publishDraggedEvent {
+	[self.bridge.eventDispatcher
+	 sendDeviceEventWithName:@"onDragEvent"
+	 body:@{@"dragged": @YES}];
+}
+
 @end


### PR DESCRIPTION
Note: There's a potential breaking change with `findNodeHandle`.

The iOS version doesn't do a few things (at least that I could tell) that is mentioned in the README. This change supports a subset of it, `showNativeButtons`, `saveImage`, and `resetImage`. This change mainly brings iOS closer to the Android implementation.

- This changes the code to the latest ReactNative, where `findNodeHandle` is no longer part of React.
- Exposes `saveImage` and `resetImage` in the iOS code base
- Obey `showNativeButtons` option

With `showNativeButtons={true}` or left out:
![screen shot 2016-09-23 at 10 53 04 am](https://cloud.githubusercontent.com/assets/545898/18796168/e80f897a-817c-11e6-8051-1b91e693cb58.png)

With `showNativeButtons={false}`:
![screen shot 2016-09-23 at 10 48 23 am](https://cloud.githubusercontent.com/assets/545898/18796184/f3f70088-817c-11e6-8427-489392eada6a.png)
