### PR TITLE
Fix React.findNodeHandle is not a function

### DIFF
--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -65,7 +65,7 @@ class SignatureCapture extends React.Component {
 
     saveImage() {
         UIManager.dispatchViewManagerCommand(
-            React.findNodeHandle(this),
+            ReactNative.findNodeHandle(this),
             UIManager.RSSignatureView.Commands.saveImage,
             [],
         );
@@ -73,7 +73,7 @@ class SignatureCapture extends React.Component {
 
     resetImage() {
         UIManager.dispatchViewManagerCommand(
-            React.findNodeHandle(this),
+            ReactNative.findNodeHandle(this),
             UIManager.RSSignatureView.Commands.resetImage,
             [],
         );


### PR DESCRIPTION
findNodeHandle is not exported by React anymore,
it is available from ReactNative