### PR TITLE
Fix bug where event handlers are not removed

### DIFF
--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -18,6 +18,7 @@ class SignatureCapture extends React.Component {
     constructor() {
         super();
         this.onChange = this.onChange.bind(this);
+        this.subscriptions = [];
     }
 
     onChange(event) {
@@ -45,25 +46,25 @@ class SignatureCapture extends React.Component {
 
     componentDidMount() {
         if (this.props.onSaveEvent) {
-            this.subscription = DeviceEventEmitter.addListener(
+            let sub = DeviceEventEmitter.addListener(
                 'onSaveEvent',
                 this.props.onSaveEvent
             );
+            this.subscriptions.push(sub);
         }
 
         if (this.props.onDragEvent) {
-            this.subscription = DeviceEventEmitter.addListener(
+            let sub = DeviceEventEmitter.addListener(
                 'onDragEvent',
                 this.props.onDragEvent
             );
+            this.subscriptions.push(sub);
         }
     }
 
     componentWillUnmount() {
-        if (this.subscription) {
-            this.subscription.remove()
-            this.subscription = null;
-        }
+        this.subscriptions.forEach(sub => sub.remove());
+        this.subscriptions = [];
     }
 
     render() {


### PR DESCRIPTION
At least on iOS, when registered for both onSaveEvent and onDragEvent,
the onDragEvent causes the onSaveEvent subscription to be leaked. This
results in the onSaveEvent firing multiple times after being unounted.

This change saves all subscriptions to an array and will remove all
listeners when unmounting.