### PR TITLE
Update for React Native 0.40

### DIFF
--- a/ios/RSSignatureView.h
+++ b/ios/RSSignatureView.h
@@ -1,7 +1,7 @@
 #import "PPSSignatureView.h"
 #import <UIKit/UIKit.h>
-#import "RCTView.h"
-#import "RCTBridge.h"
+#import <React/RCTView.h>
+#import <React/RCTBridge.h>
 
 @class RSSignatureViewManager;
 

--- a/ios/RSSignatureView.m
+++ b/ios/RSSignatureView.m
@@ -1,5 +1,5 @@
 #import "RSSignatureView.h"
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 #import <UIKit/UIKit.h>
 #import <QuartzCore/QuartzCore.h>
 #import "PPSSignatureView.h"

--- a/ios/RSSignatureViewManager.h
+++ b/ios/RSSignatureViewManager.h
@@ -1,5 +1,5 @@
 #import "RSSignatureView.h"
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface RSSignatureViewManager : RCTViewManager
 @property (nonatomic, strong) RSSignatureView *signView;

--- a/ios/RSSignatureViewManager.m
+++ b/ios/RSSignatureViewManager.m
@@ -1,7 +1,7 @@
 #import "RSSignatureViewManager.h"
-#import "RCTBridgeModule.h"
-#import "RCTBridge.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTBridge.h>
+#import <React/RCTEventDispatcher.h>
 
 @implementation RSSignatureViewManager
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-signature-capture",
-  "version": "0.4.4",
+  "version": "1.0.0",
   "description": "Lets users sign their signatures",
   "main": "SignatureCapture.js",
   "scripts": {
@@ -17,7 +17,7 @@
     "signature"
   ],
   "peerDependencies": {
-    "react-native": ">=0.29"
+    "react-native": ">=0.40"
   },
   "author": "RepairShopr",
   "license": "ISC",


### PR DESCRIPTION
React Native 0.40 included [a backwards incompatible breaking change](https://github.com/facebook/react-native/releases/tag/v0.40.0) where the iOS headers moved into a 'React' namespace.

This commit changes all references to old React header files, and bumps the version to 1.0.0 as per Semantic Versioning.