### PR TITLE
Made title label optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ class CustomComponent extends Component {
 
 + **showNativeButtons** : If this props is made to true, it will display the native buttons "Save" and "Reset".
 
++ **showTitleLabel** : If this props is made to true, it will display the "x_ _ _ _ _ _ _ _ _ _ _" placeholder indicating where to sign.
+
 + **viewMode** : "portrait" or "landscape" change the screen orientation based on boolean value
 
 + **maxSize**  : sets the max size of the image maintains aspect ratio, default is 500
@@ -157,6 +159,7 @@ class RNSignatureExample extends Component {
                     onDragEvent={this._onDragEvent}
                     saveImageFileInExtStorage={false}
                     showNativeButtons={false}
+                    showTitleLabel={false}
                     viewMode={"portrait"}/>
 
                 <View style={{ flex: 1, flexDirection: "row" }}>

--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -97,6 +97,7 @@ SignatureCapture.propTypes = {
     saveImageFileInExtStorage: PropTypes.bool,
     viewMode: PropTypes.string,
     showNativeButtons: PropTypes.bool,
+    showTitleLabel: PropTypes.bool,
     maxSize:PropTypes.number
 };
 

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
@@ -38,6 +38,7 @@ public class RSSignatureCaptureMainView extends LinearLayout implements OnClickL
   Boolean saveFileInExtStorage = false;
   String viewMode = "portrait";
   Boolean showNativeButtons = true;
+  Boolean showTitleLabel = true;
   int maxSize = 500;
 
   public RSSignatureCaptureMainView(Context context, Activity activity) {

--- a/ios/RSSignatureView.m
+++ b/ios/RSSignatureView.m
@@ -17,6 +17,7 @@
 	BOOL _rotateClockwise;
 	BOOL _square;
 	BOOL _showNativeButtons;
+	BOOL _showTitleLabel;
 }
 
 @synthesize sign;
@@ -25,15 +26,16 @@
 - (instancetype)init
 {
 	_showNativeButtons = YES;
+	_showTitleLabel = YES;
 	if ((self = [super init])) {
 		_border = [CAShapeLayer layer];
 		_border.strokeColor = [UIColor blackColor].CGColor;
 		_border.fillColor = nil;
 		_border.lineDashPattern = @[@4, @2];
-		
+
 		[self.layer addSublayer:_border];
 	}
-	
+
 	return self;
 }
 
@@ -49,33 +51,35 @@
 {
 	[super layoutSubviews];
 	if (!_loaded) {
-		
+
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didRotate:)
 																								 name:UIDeviceOrientationDidChangeNotification object:nil];
-		
+
 		_context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
-		
+
 		CGSize screen = self.bounds.size;
-		
+
 		sign = [[PPSSignatureView alloc]
 						initWithFrame: CGRectMake(0, 0, screen.width, screen.height)
 						context: _context];
 		sign.manager = manager;
-		
+
 		[self addSubview:sign];
-		
+
 		if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ) {
-			
-			titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.bounds.size.width, 24)];
-			[titleLabel setCenter:CGPointMake(self.bounds.size.width/2, self.bounds.size.height - 120)];
-			
-			[titleLabel setText:@"x_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _"];
-			[titleLabel setLineBreakMode:NSLineBreakByClipping];
-			[titleLabel setTextAlignment: NSTextAlignmentCenter];
-			[titleLabel setTextColor:[UIColor colorWithRed:200/255.f green:200/255.f blue:200/255.f alpha:1.f]];
-			//[titleLabel setBackgroundColor:[UIColor greenColor]];
-			[sign addSubview:titleLabel];
-			
+
+			if (_showTitleLabel) {
+				titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.bounds.size.width, 24)];
+				[titleLabel setCenter:CGPointMake(self.bounds.size.width/2, self.bounds.size.height - 120)];
+
+				[titleLabel setText:@"x_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _"];
+				[titleLabel setLineBreakMode:NSLineBreakByClipping];
+				[titleLabel setTextAlignment: NSTextAlignmentCenter];
+				[titleLabel setTextColor:[UIColor colorWithRed:200/255.f green:200/255.f blue:200/255.f alpha:1.f]];
+				//[titleLabel setBackgroundColor:[UIColor greenColor]];
+				[sign addSubview:titleLabel];
+			}
+
 			if (_showNativeButtons) {
 				//Save button
 				saveButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
@@ -105,17 +109,19 @@
 			}
 		}
 		else {
-			
-			titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.bounds.size.height - 80, 24)];
-			[titleLabel setCenter:CGPointMake(40, self.bounds.size.height/2)];
-			[titleLabel setTransform:CGAffineTransformMakeRotation(DEGREES_TO_RADIANS(90))];
-			[titleLabel setText:@"x_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _"];
-			[titleLabel setLineBreakMode:NSLineBreakByClipping];
-			[titleLabel setTextAlignment: NSTextAlignmentLeft];
-			[titleLabel setTextColor:[UIColor colorWithRed:200/255.f green:200/255.f blue:200/255.f alpha:1.f]];
-			//[titleLabel setBackgroundColor:[UIColor greenColor]];
-			[sign addSubview:titleLabel];
-			
+
+			if (_showTitleLabel) {
+				titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.bounds.size.height - 80, 24)];
+				[titleLabel setCenter:CGPointMake(40, self.bounds.size.height/2)];
+				[titleLabel setTransform:CGAffineTransformMakeRotation(DEGREES_TO_RADIANS(90))];
+				[titleLabel setText:@"x_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _"];
+				[titleLabel setLineBreakMode:NSLineBreakByClipping];
+				[titleLabel setTextAlignment: NSTextAlignmentLeft];
+				[titleLabel setTextColor:[UIColor colorWithRed:200/255.f green:200/255.f blue:200/255.f alpha:1.f]];
+				//[titleLabel setBackgroundColor:[UIColor greenColor]];
+				[sign addSubview:titleLabel];
+			}
+
 			if (_showNativeButtons) {
 				//Save button
 				saveButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
@@ -144,7 +150,7 @@
 				[sign addSubview:clearButton];
 			}
 		}
-		
+
 	}
 	_loaded = true;
 	_border.path = [UIBezierPath bezierPathWithRect:self.bounds].CGPath;
@@ -163,6 +169,10 @@
 	_showNativeButtons = showNativeButtons;
 }
 
+- (void)setShowTitleLabel:(BOOL)showTitleLabel {
+	_showTitleLabel = showTitleLabel;
+}
+
 -(void) onSaveButtonPressed {
 	[self saveImage];
 }
@@ -171,16 +181,16 @@
 	saveButton.hidden = YES;
 	clearButton.hidden = YES;
 	UIImage *signImage = [self.sign signatureImage: _rotateClockwise withSquare:_square];
-	
+
 	saveButton.hidden = NO;
 	clearButton.hidden = NO;
-	
+
 	NSError *error;
-	
+
 	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
 	NSString *documentsDirectory = [paths firstObject];
 	NSString *tempPath = [documentsDirectory stringByAppendingFormat:@"/signature.png"];
-	
+
 	//remove if file already exists
 	if ([[NSFileManager defaultManager] fileExistsAtPath:tempPath]) {
 		[[NSFileManager defaultManager] removeItemAtPath:tempPath error:&error];
@@ -188,7 +198,7 @@
 			NSLog(@"Error: %@", error.debugDescription);
 		}
 	}
-	
+
 	// Convert UIImage object into NSData (a wrapper for a stream of bytes) formatted according to PNG spec
 	NSData *imageData = UIImagePNGRepresentation(signImage);
 	BOOL isSuccess = [imageData writeToFile:tempPath atomically:YES];
@@ -196,7 +206,7 @@
 		NSFileManager *man = [NSFileManager defaultManager];
 		NSDictionary *attrs = [man attributesOfItemAtPath:tempPath error: NULL];
 		//UInt32 result = [attrs fileSize];
-		
+
 		NSString *base64Encoded = [imageData base64EncodedStringWithOptions:0];
 		[self.manager publishSaveImageEvent: tempPath withEncoded:base64Encoded];
 	}

--- a/ios/RSSignatureViewManager.m
+++ b/ios/RSSignatureViewManager.m
@@ -13,6 +13,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(rotateClockwise, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(square, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showNativeButtons, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(showTitleLabel, BOOL)
 
 
 -(dispatch_queue_t) methodQueue


### PR DESCRIPTION
Fix #37 and #48

## Description
Adds a `showTitleLabel` property that show or hide the `x _ _ _ _ _ _ _ _ _` placeholder below the signature on iOs.

## Usage
It works just like the `showNativeButtons` property:

```javascript
<SignatureCapture showTitleLabel={false} showNativeButtons={false} />
```

## Result

A nice, empty signature screen:

![capture d ecran 2017-04-03 a 15 31 49](https://cloud.githubusercontent.com/assets/1846873/24611529/b9bdc85a-1882-11e7-8ac4-db9f7746c6a8.png)
