### PR TITLE
detecting rotation in base of orientation

### DIFF
--- a/ios/RSSignatureView.m
+++ b/ios/RSSignatureView.m
@@ -66,7 +66,9 @@
 
 		[self addSubview:sign];
 
-		if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ) {
+		UIDeviceOrientation deviceOrientation = [[UIDevice currentDevice] orientation];
+
+		if ( deviceOrientation==UIInterfaceOrientationLandscapeRight || deviceOrientation==UIInterfaceOrientationLandscapeLeft ) {
 
 			if (_showTitleLabel) {
 				titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.bounds.size.width, 24)];


### PR DESCRIPTION
Seems that the current codebase assumes that all iPhone applications run in portrait mode, and iPad apps in landscape mode. This patch fixes the issue, by matching against current orientation.