### PR TITLE
allow multiple signature views on single page in ios

### DIFF
--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -15,38 +15,17 @@ class SignatureCapture extends React.Component {
 
     constructor() {
         super();
-        this.onChange = this.onChange.bind(this);
         this.subscriptions = [];
-    }
-
-    onChange(event) {
-
-        if(event.nativeEvent.pathName){
-
-            if (!this.props.onSaveEvent) {
-                return;
-            }
-            this.props.onSaveEvent({
-                pathName: event.nativeEvent.pathName,
-                encoded: event.nativeEvent.encoded,
-            });
-        }
-
-        if(event.nativeEvent.dragged){
-            if (!this.props.onDragEvent) {
-                return;
-            }
-            this.props.onDragEvent({
-                dragged: event.nativeEvent.dragged
-            });
-        }
     }
 
     componentDidMount() {
         if (this.props.onSaveEvent) {
             let sub = DeviceEventEmitter.addListener(
                 'onSaveEvent',
-                this.props.onSaveEvent
+                (payload) => {
+                  if(payload.reactTag === ReactNative.findNodeHandle(this))
+                    this.props.onSaveEvent(payload)
+                }
             );
             this.subscriptions.push(sub);
         }
@@ -58,6 +37,8 @@ class SignatureCapture extends React.Component {
             );
             this.subscriptions.push(sub);
         }
+
+        console.log(this.subscriptions);
     }
 
     componentWillUnmount() {
@@ -67,7 +48,7 @@ class SignatureCapture extends React.Component {
 
     render() {
         return (
-            <RSSignatureView {...this.props} onChange={this.onChange} />
+            <RSSignatureView {...this.props} />
         );
     }
 

--- a/ios/RSSignatureView.h
+++ b/ios/RSSignatureView.h
@@ -10,6 +10,6 @@
 @property (nonatomic, strong) RSSignatureViewManager *manager;
 -(void) onSaveButtonPressed;
 -(void) onClearButtonPressed;
--(void) saveImage;
+-(void) saveImage:(NSNumber *)reactTag;
 -(void) erase;
 @end

--- a/ios/RSSignatureView.m
+++ b/ios/RSSignatureView.m
@@ -174,10 +174,10 @@
 }
 
 -(void) onSaveButtonPressed {
-	[self saveImage];
+	[self saveImage: nil];
 }
 
--(void) saveImage {
+-(void) saveImage:(NSNumber *)reactTag {
 	saveButton.hidden = YES;
 	clearButton.hidden = YES;
 	UIImage *signImage = [self.sign signatureImage: _rotateClockwise withSquare:_square];
@@ -208,7 +208,10 @@
 		//UInt32 result = [attrs fileSize];
 
 		NSString *base64Encoded = [imageData base64EncodedStringWithOptions:0];
-		[self.manager publishSaveImageEvent: tempPath withEncoded:base64Encoded];
+		[self.manager
+			publishSaveImageEvent: tempPath
+			withEncoded:base64Encoded
+      withReactTag: reactTag];
 	}
 }
 

--- a/ios/RSSignatureViewManager.h
+++ b/ios/RSSignatureViewManager.h
@@ -5,6 +5,6 @@
 @property (nonatomic, strong) RSSignatureView *signView;
 -(void) saveImage:(nonnull NSNumber *)reactTag;
 -(void) resetImage:(nonnull NSNumber *)reactTag;
--(void) publishSaveImageEvent:(NSString *) aTempPath withEncoded: (NSString *) aEncoded;
+-(void) publishSaveImageEvent:(NSString *) aTempPath withEncoded: (NSString *) aEncoded withReactTag: (NSNumber *) reactTag;
 -(void) publishDraggedEvent;
 @end

--- a/ios/RSSignatureViewManager.m
+++ b/ios/RSSignatureViewManager.m
@@ -2,6 +2,7 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
+#import <React/RCTUIManager.h>
 
 @implementation RSSignatureViewManager
 
@@ -28,19 +29,20 @@ RCT_EXPORT_VIEW_PROPERTY(showTitleLabel, BOOL)
 	return signView;
 }
 
-// Both of these methods needs to be called from the main thread so the
-// UI can clear out the signature.
 RCT_EXPORT_METHOD(saveImage:(nonnull NSNumber *)reactTag) {
-	dispatch_async(dispatch_get_main_queue(), ^{
-		[self.signView saveImage];
-	});
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        RSSignatureView *view = viewRegistry[reactTag];
+        [view saveImage];
+    }];
 }
 
 RCT_EXPORT_METHOD(resetImage:(nonnull NSNumber *)reactTag) {
-	dispatch_async(dispatch_get_main_queue(), ^{
-		[self.signView erase];
-	});
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        RSSignatureView *view = viewRegistry[reactTag];
+        [view erase];
+    }];
 }
+
 
 -(void) publishSaveImageEvent:(NSString *) aTempPath withEncoded: (NSString *) aEncoded {
 	[self.bridge.eventDispatcher

--- a/ios/RSSignatureViewManager.m
+++ b/ios/RSSignatureViewManager.m
@@ -32,7 +32,7 @@ RCT_EXPORT_VIEW_PROPERTY(showTitleLabel, BOOL)
 RCT_EXPORT_METHOD(saveImage:(nonnull NSNumber *)reactTag) {
     [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
         RSSignatureView *view = viewRegistry[reactTag];
-        [view saveImage];
+        [view saveImage: reactTag];
     }];
 }
 
@@ -44,13 +44,16 @@ RCT_EXPORT_METHOD(resetImage:(nonnull NSNumber *)reactTag) {
 }
 
 
--(void) publishSaveImageEvent:(NSString *) aTempPath withEncoded: (NSString *) aEncoded {
+-(void) publishSaveImageEvent:(NSString *) aTempPath
+				withEncoded: (NSString *) aEncoded
+				withReactTag: (NSNumber *) reactTag {
 	[self.bridge.eventDispatcher
 	 sendDeviceEventWithName:@"onSaveEvent"
 	 body:@{
 					@"pathName": aTempPath,
-					@"encoded": aEncoded
-					}];
+					@"encoded": aEncoded,
+          @"reactTag": reactTag
+				}];
 }
 
 -(void) publishDraggedEvent {


### PR DESCRIPTION
I found a bug which does not allow you to include the signature pad in two places on the same page on iOS.  The second signature was overwriting the first.  

Rather than keeping only one reference to a RSSignatureView instance, this revision uses the bridge to dynamically find the correct component.