### PR TITLE
Feature stroke color

### DIFF
--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -96,7 +96,8 @@ SignatureCapture.propTypes = {
     viewMode: PropTypes.string,
     showNativeButtons: PropTypes.bool,
     showTitleLabel: PropTypes.bool,
-    maxSize:PropTypes.number
+    maxSize:PropTypes.number,
+    strokeColor: PropTypes.string
 };
 
 var RSSignatureView = requireNativeComponent('RSSignatureView', SignatureCapture, {

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
@@ -72,6 +72,10 @@ public class RSSignatureCaptureMainView extends LinearLayout implements OnClickL
     }
   }
 
+  public void setStrokeColor(String strokeColor) {
+    this.signatureView.setStrokeColor(Color.parseColor(strokeColor));
+  }
+
   public void setShowNativeButtons(Boolean showNativeButtons) {
     this.showNativeButtons = showNativeButtons;
     if (showNativeButtons) {

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -71,7 +71,6 @@ public class RSSignatureCaptureView extends View {
 		mMinWidth = convertDpToPx(8);
 		mMaxWidth = convertDpToPx(16);
 		mVelocityFilterWeight = 0.4f;
-		mPaint.setColor(Color.BLACK);
 
 		//Dirty rectangle to update only the changed portion of the view
 		mDirtyRect = new RectF();
@@ -106,6 +105,12 @@ public class RSSignatureCaptureView extends View {
 		return signatureBitmap;
 	}
 
+	/**
+	 * Set stroke color
+	 */
+	public void setStrokeColor(int strokeColor) {
+		mPaint.setColor(strokeColor);
+	}
 
 	/**
 	* clear signature canvas

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureViewManager.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureViewManager.java
@@ -21,6 +21,7 @@ public class RSSignatureCaptureViewManager extends ViewGroupManager<RSSignatureC
 	public static final String PROPS_VIEW_MODE = "viewMode";
 	public static final String PROPS_SHOW_NATIVE_BUTTONS="showNativeButtons";
 	public static final String PROPS_MAX_SIZE="maxSize";
+	public static final String PROPS_STROKE_COLOR="strokeColor";
 
 	public static final int COMMAND_SAVE_IMAGE = 1;
 	public static final int COMMAND_RESET_IMAGE = 2;
@@ -34,6 +35,14 @@ public class RSSignatureCaptureViewManager extends ViewGroupManager<RSSignatureC
 	@Override
 	public String getName() {
 		return "RSSignatureView";
+	}
+
+	@ReactProp(name = PROPS_STROKE_COLOR)
+	public void setStrokeColor(RSSignatureCaptureMainView view, @Nullable String strokeColor) {
+		Log.d("setStrokeColor:", "" + strokeColor);
+		if(view!=null) {
+			view.setStrokeColor(strokeColor);
+		}
 	}
 
 	@ReactProp(name = PROPS_SAVE_IMAGE_FILE)


### PR DESCRIPTION
It provide stroke color as props in JS definition. Also it is only possible on Android currently. Reference to #81
Here's an example:
```
<SignatureCapture 
    style={{flex: 1}} 
    ref="sign" 
    onSaveEvent={this._onSaveEvent} 
    onDragEvent={this._onDragEvent} 
    saveImageFileInExtStorage={false} 
    showNativeButtons={false} 
    showTitleLabel={false} 
    viewMode={"portrait"} 
    strokeColor="#3BC7C1" />
```