### PR TITLE
Don't Save to File System on iOS without "saveImageFileInExtStorage"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ project.xcworkspace
 .idea
 .gradle
 local.properties
+*.iml
 
 # node.js
 #

--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -20,8 +20,7 @@ class SignatureCapture extends React.Component {
     }
 
     onChange(event) {
-
-        if(event.nativeEvent.pathName){
+        if(event.nativeEvent.encoded){
 
             if (!this.props.onSaveEvent) {
                 return;

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
@@ -173,8 +173,9 @@ public class RSSignatureCaptureMainView extends LinearLayout implements OnClickL
       byte[] byteArray = byteArrayOutputStream.toByteArray();
       String encoded = Base64.encodeToString(byteArray, Base64.DEFAULT);
 
+      // If we didn't actually write the image to the file system, use empty string as the "pathName"
       WritableMap event = Arguments.createMap();
-      event.putString("pathName", file.getAbsolutePath());
+      event.putString("pathName", saveFileInExtStorage ? file.getAbsolutePath() : "");
       event.putString("encoded", encoded);
       ReactContext reactContext = (ReactContext) getContext();
       reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topChange", event);

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -2,10 +2,6 @@ package com.rssignaturecapture;
 
 import android.content.Context;
 
-import android.content.res.Resources;
-import android.content.res.TypedArray;
-
-import android.util.Log;
 import android.view.View;
 import android.view.MotionEvent;
 
@@ -86,22 +82,25 @@ public class RSSignatureCaptureView extends View {
 	}
 
 	/**
-	* Get signature
-	*
-	* @return
+	* Get signature as a Bitmap
 	*/
 	public Bitmap getSignature() {
+		// Initialize a Bitmap to contain the signature
+		Bitmap signatureBitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(), Bitmap.Config.ARGB_8888);
 
-		Bitmap signatureBitmap = null;
-
-		// set the signature bitmap
-		if (signatureBitmap == null) {
-			signatureBitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(), Bitmap.Config.RGB_565);
-		}
-
-		// important for saving signature
+		// This view's pixels constitute the signature, so draw this view onto the signatureBitmap
 		final Canvas canvas = new Canvas(signatureBitmap);
 		this.draw(canvas);
+
+		// The signatureBitmap now contains the signature with a white background,
+		// so we will change it to a transparent background.
+		for (int x = 0; x < signatureBitmap.getWidth(); x++) {
+			for (int y = 0; y < signatureBitmap.getHeight(); y++) {
+				if (Color.WHITE == signatureBitmap.getPixel(x, y)) {
+					signatureBitmap.setPixel(x, y, Color.TRANSPARENT);
+				}
+			}
+		}
 
 		return signatureBitmap;
 	}

--- a/ios/RSSignatureView.m
+++ b/ios/RSSignatureView.m
@@ -18,6 +18,7 @@
 	BOOL _square;
 	BOOL _showNativeButtons;
 	BOOL _showTitleLabel;
+    BOOL _saveImageFileInExtStorage;
 }
 
 @synthesize sign;
@@ -173,11 +174,15 @@
 	_showTitleLabel = showTitleLabel;
 }
 
--(void) onSaveButtonPressed {
+- (void)setSaveImageFileInExtStorage:(BOOL)saveImageFileInExtStorage {
+    _saveImageFileInExtStorage = saveImageFileInExtStorage;
+}
+
+- (void) onSaveButtonPressed {
 	[self saveImage];
 }
 
--(void) saveImage {
+- (void) saveImage {
 	saveButton.hidden = YES;
 	clearButton.hidden = YES;
 	UIImage *signImage = [self.sign signatureImage: _rotateClockwise withSquare:_square];
@@ -186,30 +191,32 @@
 	clearButton.hidden = NO;
 
 	NSError *error;
-
 	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
 	NSString *documentsDirectory = [paths firstObject];
 	NSString *tempPath = [documentsDirectory stringByAppendingFormat:@"/signature.png"];
 
-	//remove if file already exists
+	// Remove if file already exists
 	if ([[NSFileManager defaultManager] fileExistsAtPath:tempPath]) {
 		[[NSFileManager defaultManager] removeItemAtPath:tempPath error:&error];
 		if (error) {
 			NSLog(@"Error: %@", error.debugDescription);
 		}
 	}
-
-	// Convert UIImage object into NSData (a wrapper for a stream of bytes) formatted according to PNG spec
-	NSData *imageData = UIImagePNGRepresentation(signImage);
-	BOOL isSuccess = [imageData writeToFile:tempPath atomically:YES];
-	if (isSuccess) {
-		NSFileManager *man = [NSFileManager defaultManager];
-		NSDictionary *attrs = [man attributesOfItemAtPath:tempPath error: NULL];
-		//UInt32 result = [attrs fileSize];
-
-		NSString *base64Encoded = [imageData base64EncodedStringWithOptions:0];
-		[self.manager publishSaveImageEvent: tempPath withEncoded:base64Encoded];
-	}
+    
+    NSData *imageData = UIImagePNGRepresentation(signImage);
+    NSString *base64Encoded = [imageData base64EncodedStringWithOptions:0];
+    
+    // Don't save to file system unless this prop was set to true
+    if (_saveImageFileInExtStorage) {
+        BOOL isSuccess = [imageData writeToFile:tempPath atomically:YES];
+        if (!isSuccess) NSLog(@"Error: Failed to write image to %@", tempPath);
+        [self.manager publishSaveImageEvent:tempPath withEncoded:base64Encoded];
+    
+    }
+    // Just return the base64 image if the prop was set to false or not specified
+    else {
+        [self.manager publishSaveImageEvent:@"" withEncoded:base64Encoded];
+    }
 }
 
 -(void) onClearButtonPressed {

--- a/ios/RSSignatureViewManager.m
+++ b/ios/RSSignatureViewManager.m
@@ -14,6 +14,7 @@ RCT_EXPORT_VIEW_PROPERTY(rotateClockwise, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(square, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showNativeButtons, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showTitleLabel, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(saveImageFileInExtStorage, BOOL)
 
 
 -(dispatch_queue_t) methodQueue
@@ -46,9 +47,9 @@ RCT_EXPORT_METHOD(resetImage:(nonnull NSNumber *)reactTag) {
 	[self.bridge.eventDispatcher
 	 sendDeviceEventWithName:@"onSaveEvent"
 	 body:@{
-					@"pathName": aTempPath,
-					@"encoded": aEncoded
-					}];
+        @"pathName": aTempPath,
+        @"encoded": aEncoded
+     }];
 }
 
 -(void) publishDraggedEvent {


### PR DESCRIPTION
Fixes #69. 

In Android, the signature PNG file is never saved to the file system unless the `saveImageFileInExtStorage` prop is set to true. This is not currently true of iOS, though. In iOS, the image file is _always_ saved to the file system, even if `saveImageFileInExtStorage` is set to false. (This is especially problematic is there are legal restrictions for an app that prevent the signature from being saved to the device's file system.)

This branch fixes that by only returning the base64 encoded signature if `saveImageFileInExtStorage` is not defined or is set to false. Note that this branch also includes some changes introduced in #87. If necessary, I can pull those changes out of this merge request.