### PR TITLE
Support multiple signature pads and targeted events

### DIFF
--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -15,59 +15,32 @@ class SignatureCapture extends React.Component {
 
     constructor() {
         super();
-        this.onChange = this.onChange.bind(this);
-        this.subscriptions = [];
+        this.onSave = this.onSave.bind(this);
+        this.onDrag = this.onDrag.bind(this);
     }
 
-    onChange(event) {
-
-        if(event.nativeEvent.pathName){
-
-            if (!this.props.onSaveEvent) {
-                return;
-            }
-            this.props.onSaveEvent({
-                pathName: event.nativeEvent.pathName,
-                encoded: event.nativeEvent.encoded,
-            });
+    onSave(event) {
+        if (!this.props.onSaveEvent) {
+            return;
         }
-
-        if(event.nativeEvent.dragged){
-            if (!this.props.onDragEvent) {
-                return;
-            }
-            this.props.onDragEvent({
-                dragged: event.nativeEvent.dragged
-            });
-        }
+        this.props.onSaveEvent({
+            pathName: event.pathName,
+            encoded: event.nativeEvent.encoded,
+        });
     }
 
-    componentDidMount() {
-        if (this.props.onSaveEvent) {
-            let sub = DeviceEventEmitter.addListener(
-                'onSaveEvent',
-                this.props.onSaveEvent
-            );
-            this.subscriptions.push(sub);
+    onDrag(event) {
+        if (!this.props.onDragEvent) {
+            return;
         }
-
-        if (this.props.onDragEvent) {
-            let sub = DeviceEventEmitter.addListener(
-                'onDragEvent',
-                this.props.onDragEvent
-            );
-            this.subscriptions.push(sub);
-        }
-    }
-
-    componentWillUnmount() {
-        this.subscriptions.forEach(sub => sub.remove());
-        this.subscriptions = [];
+        this.props.onDragEvent({
+            dragged: event.dragged
+        });
     }
 
     render() {
         return (
-            <RSSignatureView {...this.props} onChange={this.onChange} />
+            <RSSignatureView {...this.props} onSave={this.onSave} onDrag={this.onDrag} />
         );
     }
 
@@ -89,7 +62,7 @@ class SignatureCapture extends React.Component {
 }
 
 SignatureCapture.propTypes = {
-  ...View.propTypes,
+    ...View.propTypes,
     rotateClockwise: PropTypes.bool,
     square: PropTypes.bool,
     saveImageFileInExtStorage: PropTypes.bool,
@@ -97,11 +70,13 @@ SignatureCapture.propTypes = {
     showBorder: PropTypes.bool,
     showNativeButtons: PropTypes.bool,
     showTitleLabel: PropTypes.bool,
-    maxSize:PropTypes.number
+    maxSize:PropTypes.number,
+    onSaveEvent: PropTypes.func,
+    onDragEvent: PropTypes.func,
 };
 
 var RSSignatureView = requireNativeComponent('RSSignatureView', SignatureCapture, {
-    nativeOnly: { onChange: true }
+    nativeOnly: { onSave: true, onDrag: true }
 });
 
 module.exports = SignatureCapture;

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
@@ -178,7 +178,7 @@ public class RSSignatureCaptureMainView extends LinearLayout implements OnClickL
       event.putString("pathName", file.getAbsolutePath());
       event.putString("encoded", encoded);
       ReactContext reactContext = (ReactContext) getContext();
-      reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topChange", event);
+      reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "saveSignature", event);
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -212,7 +212,7 @@ public class RSSignatureCaptureMainView extends LinearLayout implements OnClickL
     WritableMap event = Arguments.createMap();
     event.putBoolean("dragged", true);
     ReactContext reactContext = (ReactContext) getContext();
-    reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topChange", event);
+    reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "drag", event);
 
   }
 }

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureViewManager.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureViewManager.java
@@ -36,6 +36,17 @@ public class RSSignatureCaptureViewManager extends ViewGroupManager<RSSignatureC
 		return "RSSignatureView";
 	}
 
+        @Override
+        @Nullable
+        public Map getExportedCustomDirectEventTypeConstants() {
+            return MapBuilder.of(
+                "saveSignature",
+                MapBuilder.of("registrationName", "onSave"),
+                "drag",
+                MapBuilder.of("registrationName", "onDrag")
+            );
+        }
+
 	@ReactProp(name = PROPS_SAVE_IMAGE_FILE)
 	public void setSaveImageFileInExtStorage(RSSignatureCaptureMainView view, @Nullable Boolean saveFile) {
 		Log.d("setFileInExtStorage:", "" + saveFile);

--- a/ios/PPSSignatureView.m
+++ b/ios/PPSSignatureView.m
@@ -414,7 +414,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 		addVertex(&length, previousVertex);
 		
 		self.hasSignature = YES;
-		[self.manager publishDraggedEvent];
+                ((RSSignatureView *)self.superview).onDrag(@{@"dragged": @YES});
 		
 	} else if ([p state] == UIGestureRecognizerStateChanged) {
 		

--- a/ios/PPSSignatureView.m
+++ b/ios/PPSSignatureView.m
@@ -35,11 +35,11 @@ static inline void addVertex(uint *length, PPSSignaturePoint v) {
 	if ((*length) >= maxLength) {
 		return;
 	}
-	
+
 	GLvoid *data = glMapBufferOES(GL_ARRAY_BUFFER, GL_WRITE_ONLY_OES);
 	memcpy(data + sizeof(PPSSignaturePoint) * (*length), &v, sizeof(PPSSignaturePoint));
 	glUnmapBufferOES(GL_ARRAY_BUFFER);
-	
+
 	(*length)++;
 }
 
@@ -47,7 +47,7 @@ static inline CGPoint QuadraticPointInCurve(CGPoint start, CGPoint end, CGPoint 
 	double a = pow((1.0 - percent), 2.0);
 	double b = 2.0 * percent * (1.0 - percent);
 	double c = pow(percent, 2.0);
-	
+
 	return (CGPoint) {
 		a * start.x + b * controlPoint.x + c * end.x,
 		a * start.y + b * controlPoint.y + c * end.y
@@ -68,7 +68,7 @@ static GLKVector3 perpendicular(PPSSignaturePoint p1, PPSSignaturePoint p2) {
 }
 
 static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVector3 color) {
-	
+
 	return (PPSSignaturePoint) {
 		{
 			(viewPoint.x / bounds.size.width * 2.0 - 1),
@@ -84,26 +84,26 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 	// OpenGL state
 	EAGLContext *context;
 	GLKBaseEffect *effect;
-	
+
 	GLuint vertexArray;
 	GLuint vertexBuffer;
 	GLuint dotsArray;
 	GLuint dotsBuffer;
-	
-	
+
+
 	// Array of verteces, with current length
 	PPSSignaturePoint SignatureVertexData[maxLength];
 	uint length;
-	
+
 	PPSSignaturePoint SignatureDotsData[maxLength];
 	uint dotsLength;
-	
-	
+
+
 	// Width of line at current and previous vertex
 	float penThickness;
 	float previousThickness;
-	
-	
+
+
 	// Previous points for quadratic bezier computations
 	CGPoint previousPoint;
 	CGPoint previousMidPoint;
@@ -119,34 +119,34 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)commonInit {
 	context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
-	
+
 	if (context) {
-		
+
 		time(NULL);
-		
+
 		self.backgroundColor = [UIColor whiteColor];
 		self.opaque = NO;
-		
+
 		self.context = context;
 		self.drawableDepthFormat = GLKViewDrawableDepthFormat24;
 		self.enableSetNeedsDisplay = YES;
-		
+
 		// Turn on antialiasing
 		self.drawableMultisample = GLKViewDrawableMultisample4X;
-		
+
 		[self setupGL];
-		
+
 		// Capture touches
 		UIPanGestureRecognizer *pan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(pan:)];
 		pan.maximumNumberOfTouches = pan.minimumNumberOfTouches = 1;
 		pan.cancelsTouchesInView = YES;
 		[self addGestureRecognizer:pan];
-		
+
 		// For dotting your i's
 		UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tap:)];
 		tap.cancelsTouchesInView = YES;
 		[self addGestureRecognizer:tap];
-		
+
 		// Erase with long press
 		UILongPressGestureRecognizer *longer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longPress:)];
 		longer.cancelsTouchesInView = YES;
@@ -175,11 +175,11 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 {
 	self.context = nil;
 	[self tearDownGL];
-	
+
 	if ([EAGLContext currentContext] == context) {
 		[EAGLContext setCurrentContext:nil];
 	}
-	
+
 	context = nil;
 }
 
@@ -188,15 +188,15 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 {
 	glClearColor(clearColor[0], clearColor[1], clearColor[2], clearColor[3]);
 	glClear(GL_COLOR_BUFFER_BIT);
-	
+
 	[effect prepareToDraw];
-	
+
 	// Drawing of signature lines
 	if (length > 2) {
 		glBindVertexArrayOES(vertexArray);
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, length);
 	}
-	
+
 	if (dotsLength > 0) {
 		glBindVertexArrayOES(dotsArray);
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, dotsLength);
@@ -207,13 +207,13 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 	length = 0;
 	dotsLength = 0;
 	self.hasSignature = NO;
-	
+
 	[self setNeedsDisplay];
 }
 
 - (UIImage*)imageByCombiningImage:(UIImage*)firstImage withImage:(UIImage*)secondImage {
 	UIImage *image = nil;
-	
+
 	CGSize newImageSize = CGSizeMake(MAX(firstImage.size.width, secondImage.size.width), MAX(firstImage.size.height, secondImage.size.height));
 	if (UIGraphicsBeginImageContextWithOptions != NULL) {
 		UIGraphicsBeginImageContextWithOptions(newImageSize, NO, [[UIScreen mainScreen] scale]);
@@ -226,7 +226,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 																			 roundf((newImageSize.height-secondImage.size.height)/2))];
 	image = UIGraphicsGetImageFromCurrentImageContext();
 	UIGraphicsEndImageContext();
-	
+
 	return image;
 }
 
@@ -244,17 +244,17 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 											 scale:1.0
 								 orientation:clockwise ? UIImageOrientationRight : UIImageOrientationLeft]
 	 drawInRect:CGRectMake(0,0,size.height ,size.width)];
-	
+
 	UIImage* newImage = UIGraphicsGetImageFromCurrentImageContext();
 	UIGraphicsEndImageContext();
-	
+
 	return newImage;
 }
 
 - (UIImage*) reduceImage:(UIImage*)image toSize:(CGSize)newSize {
 	CGSize scaledSize = newSize;
 	float scaleFactor = 1.0;
-	
+
 	if(image.size.width > image.size.height) {
 		scaleFactor = image.size.width / image.size.height;
 		scaledSize.width = newSize.width;
@@ -265,16 +265,16 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 		scaledSize.height = newSize.height;
 		scaledSize.width = newSize.width / scaleFactor;
 	}
-	
+
 	NSLog(@"%f x %f", scaledSize.width, scaledSize.height);
-	
+
 	UIGraphicsBeginImageContext(scaledSize);
 	CGRect scaledImageRect = CGRectMake( 0.0, 0.0, scaledSize.width, scaledSize.height );
 	[image drawInRect:scaledImageRect];
-	
+
 	UIImage* scaledImage = UIGraphicsGetImageFromCurrentImageContext();
 	UIGraphicsEndImageContext();
-	
+
 	return scaledImage;
 }
 
@@ -290,11 +290,10 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 {
 	if (!self.hasSignature)
 		return nil;
-	
+
 	UIImage *signatureImg;
 	UIImage *snapshot = [self snapshot];
-	[self erase];
-	
+
 	if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ) {
 		//signature
 		if (square) {
@@ -306,7 +305,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 	}
 	else {
 		//rotate iphone signature - iphone's signature screen is always landscape
-		
+
 		if (rotatedImage) {
 			if (square) {
 				UIImage *rotatedImg = [self rotateImage:snapshot clockwise:false];
@@ -326,7 +325,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 			}
 		}
 	}
-	
+
 	return signatureImg;
 }
 
@@ -336,17 +335,17 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)tap:(UITapGestureRecognizer *)t {
 	CGPoint l = [t locationInView:self];
-	
+
 	if (t.state == UIGestureRecognizerStateRecognized) {
 		glBindBuffer(GL_ARRAY_BUFFER, dotsBuffer);
-		
+
 		PPSSignaturePoint touchPoint = ViewPointToGL(l, self.bounds, (GLKVector3){1, 1, 1});
 		addVertex(&dotsLength, touchPoint);
-		
+
 		PPSSignaturePoint centerPoint = touchPoint;
 		centerPoint.color = StrokeColor;
 		addVertex(&dotsLength, centerPoint);
-		
+
 		static int segments = 20;
 		GLKVector2 radius = (GLKVector2){
 			clamp(0.00001, 0.02, penThickness * generateRandom(0.5, 1.5)),
@@ -354,24 +353,24 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 		};
 		GLKVector2 velocityRadius = radius;
 		float angle = 0;
-		
+
 		for (int i = 0; i <= segments; i++) {
-			
+
 			PPSSignaturePoint p = centerPoint;
 			p.vertex.x += velocityRadius.x * cosf(angle);
 			p.vertex.y += velocityRadius.y * sinf(angle);
-			
+
 			addVertex(&dotsLength, p);
 			addVertex(&dotsLength, centerPoint);
-			
+
 			angle += M_PI * 2.0 / segments;
 		}
-		
+
 		addVertex(&dotsLength, touchPoint);
-		
+
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
 	}
-	
+
 	[self setNeedsDisplay];
 }
 
@@ -381,87 +380,87 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 }
 
 - (void)pan:(UIPanGestureRecognizer *)p {
-	
+
 	glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
-	
+
 	CGPoint v = [p velocityInView:self];
 	CGPoint l = [p locationInView:self];
-	
+
 	currentVelocity = ViewPointToGL(v, self.bounds, (GLKVector3){0,0,0});
 	float distance = 0.;
 	if (previousPoint.x > 0) {
 		distance = sqrtf((l.x - previousPoint.x) * (l.x - previousPoint.x) + (l.y - previousPoint.y) * (l.y - previousPoint.y));
 	}
-	
+
 	float velocityMagnitude = sqrtf(v.x*v.x + v.y*v.y);
 	float clampedVelocityMagnitude = clamp(VELOCITY_CLAMP_MIN, VELOCITY_CLAMP_MAX, velocityMagnitude);
 	float normalizedVelocity = (clampedVelocityMagnitude - VELOCITY_CLAMP_MIN) / (VELOCITY_CLAMP_MAX - VELOCITY_CLAMP_MIN);
-	
+
 	float lowPassFilterAlpha = STROKE_WIDTH_SMOOTHING;
 	float newThickness = (STROKE_WIDTH_MAX - STROKE_WIDTH_MIN) * (1 - normalizedVelocity) + STROKE_WIDTH_MIN;
 	penThickness = penThickness * lowPassFilterAlpha + newThickness * (1 - lowPassFilterAlpha);
-	
+
 	if ([p state] == UIGestureRecognizerStateBegan) {
-		
+
 		previousPoint = l;
 		previousMidPoint = l;
-		
+
 		PPSSignaturePoint startPoint = ViewPointToGL(l, self.bounds, (GLKVector3){1, 1, 1});
 		previousVertex = startPoint;
 		previousThickness = penThickness;
-		
+
 		addVertex(&length, startPoint);
 		addVertex(&length, previousVertex);
-		
-		self.hasSignature = YES;
-                ((RSSignatureView *)self.superview).onDrag(@{@"dragged": @YES});
-		
 	} else if ([p state] == UIGestureRecognizerStateChanged) {
-		
+
 		CGPoint mid = CGPointMake((l.x + previousPoint.x) / 2.0, (l.y + previousPoint.y) / 2.0);
-		
+
 		if (distance > QUADRATIC_DISTANCE_TOLERANCE) {
 			// Plot quadratic bezier instead of line
 			unsigned int i;
-			
+
 			int segments = (int) distance / 1.5;
-			
+
 			float startPenThickness = previousThickness;
 			float endPenThickness = penThickness;
 			previousThickness = penThickness;
-			
+
 			for (i = 0; i < segments; i++)
 			{
 				penThickness = startPenThickness + ((endPenThickness - startPenThickness) / segments) * i;
-				
+
 				CGPoint quadPoint = QuadraticPointInCurve(previousMidPoint, mid, previousPoint, (float)i / (float)(segments));
-				
+
 				PPSSignaturePoint v = ViewPointToGL(quadPoint, self.bounds, StrokeColor);
 				[self addTriangleStripPointsForPrevious:previousVertex next:v];
-				
+
 				previousVertex = v;
 			}
 		} else if (distance > 1.0) {
-			
+
 			PPSSignaturePoint v = ViewPointToGL(l, self.bounds, StrokeColor);
 			[self addTriangleStripPointsForPrevious:previousVertex next:v];
-			
+
 			previousVertex = v;
 			previousThickness = penThickness;
 		}
-		
+
 		previousPoint = l;
 		previousMidPoint = mid;
-		
+
 	} else if (p.state == UIGestureRecognizerStateEnded | p.state == UIGestureRecognizerStateCancelled) {
-		
+
 		PPSSignaturePoint v = ViewPointToGL(l, self.bounds, (GLKVector3){1, 1, 1});
 		addVertex(&length, v);
-		
+
 		previousVertex = v;
 		addVertex(&length, previousVertex);
+
+		self.hasSignature = YES;
+		((RSSignatureView *)self.superview).onDrag(@{@"dragged": @YES});
+
 	}
-	
+
 	[self setNeedsDisplay];
 }
 
@@ -486,7 +485,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor {
 	[super setBackgroundColor:backgroundColor];
-	
+
 	CGFloat red, green, blue, alpha, white;
 	if ([backgroundColor getRed:&red green:&green blue:&blue alpha:&alpha]) {
 		clearColor[0] = red;
@@ -509,44 +508,44 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 - (void)setupGL
 {
 	[EAGLContext setCurrentContext:context];
-	
+
 	effect = [[GLKBaseEffect alloc] init];
-	
+
 	[self updateStrokeColor];
-	
-	
+
+
 	glDisable(GL_DEPTH_TEST);
-	
+
 	// Signature Lines
 	glGenVertexArraysOES(1, &vertexArray);
 	glBindVertexArrayOES(vertexArray);
-	
+
 	glGenBuffers(1, &vertexBuffer);
 	glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
 	glBufferData(GL_ARRAY_BUFFER, sizeof(SignatureVertexData), SignatureVertexData, GL_DYNAMIC_DRAW);
 	[self bindShaderAttributes];
-	
-	
+
+
 	// Signature Dots
 	glGenVertexArraysOES(1, &dotsArray);
 	glBindVertexArrayOES(dotsArray);
-	
+
 	glGenBuffers(1, &dotsBuffer);
 	glBindBuffer(GL_ARRAY_BUFFER, dotsBuffer);
 	glBufferData(GL_ARRAY_BUFFER, sizeof(SignatureDotsData), SignatureDotsData, GL_DYNAMIC_DRAW);
 	[self bindShaderAttributes];
-	
-	
+
+
 	glBindVertexArrayOES(0);
-	
-	
+
+
 	// Perspective
 	GLKMatrix4 ortho = GLKMatrix4MakeOrtho(-1, 1, -1, 1, 0.1f, 2.0f);
 	effect.transform.projectionMatrix = ortho;
-	
+
 	GLKMatrix4 modelViewMatrix = GLKMatrix4MakeTranslation(0.0f, 0.0f, -1.0f);
 	effect.transform.modelviewMatrix = modelViewMatrix;
-	
+
 	length = 0;
 	penThickness = 0.003;
 	previousPoint = CGPointMake(-100, -100);
@@ -556,26 +555,26 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)addTriangleStripPointsForPrevious:(PPSSignaturePoint)previous next:(PPSSignaturePoint)next {
 	float toTravel = penThickness / 2.0;
-	
+
 	for (int i = 0; i < 2; i++) {
 		GLKVector3 p = perpendicular(previous, next);
 		GLKVector3 p1 = next.vertex;
 		GLKVector3 ref = GLKVector3Add(p1, p);
-		
+
 		float distance = GLKVector3Distance(p1, ref);
 		float difX = p1.x - ref.x;
 		float difY = p1.y - ref.y;
 		float ratio = -1.0 * (toTravel / distance);
-		
+
 		difX = difX * ratio;
 		difY = difY * ratio;
-		
+
 		PPSSignaturePoint stripPoint = {
 			{ p1.x + difX, p1.y + difY, 0.0 },
 			StrokeColor
 		};
 		addVertex(&length, stripPoint);
-		
+
 		toTravel *= -1;
 	}
 }
@@ -584,13 +583,13 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 - (void)tearDownGL
 {
 	[EAGLContext setCurrentContext:context];
-	
+
 	glDeleteVertexArraysOES(1, &vertexArray);
 	glDeleteBuffers(1, &vertexBuffer);
-	
+
 	glDeleteVertexArraysOES(1, &dotsArray);
 	glDeleteBuffers(1, &dotsBuffer);
-	
+
 	effect = nil;
 }
 

--- a/ios/RSSignatureView.h
+++ b/ios/RSSignatureView.h
@@ -8,6 +8,8 @@
 @interface RSSignatureView : RCTView
 @property (nonatomic, strong) PPSSignatureView *sign;
 @property (nonatomic, strong) RSSignatureViewManager *manager;
+@property (nonatomic, copy) RCTDirectEventBlock onSave;
+@property (nonatomic, copy) RCTDirectEventBlock onDrag;
 -(void) onSaveButtonPressed;
 -(void) onClearButtonPressed;
 -(void) saveImage;

--- a/ios/RSSignatureView.m
+++ b/ios/RSSignatureView.m
@@ -214,7 +214,10 @@
 		//UInt32 result = [attrs fileSize];
 
 		NSString *base64Encoded = [imageData base64EncodedStringWithOptions:0];
-		[self.manager publishSaveImageEvent: tempPath withEncoded:base64Encoded];
+                self.onSave(@{
+                  @"pathName": tempPath,
+                  @"encoded": base64Encoded
+                });
 	}
 }
 

--- a/ios/RSSignatureViewManager.m
+++ b/ios/RSSignatureViewManager.m
@@ -2,6 +2,8 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
+#import <React/RCTUIManager.h>
+
 
 @implementation RSSignatureViewManager
 
@@ -15,6 +17,8 @@ RCT_EXPORT_VIEW_PROPERTY(square, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showBorder, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showNativeButtons, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showTitleLabel, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(onSave, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onDrag, RCTDirectEventBlock)
 
 
 -(dispatch_queue_t) methodQueue
@@ -24,38 +28,23 @@ RCT_EXPORT_VIEW_PROPERTY(showTitleLabel, BOOL)
 
 -(UIView *) view
 {
-	self.signView = [[RSSignatureView alloc] init];
-	self.signView.manager = self;
-	return signView;
+	return [[RSSignatureView alloc] init];
 }
 
 // Both of these methods needs to be called from the main thread so the
 // UI can clear out the signature.
 RCT_EXPORT_METHOD(saveImage:(nonnull NSNumber *)reactTag) {
-	dispatch_async(dispatch_get_main_queue(), ^{
-		[self.signView saveImage];
-	});
+        [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+          RSSignatureView *view = viewRegistry[reactTag];
+          [view saveImage];
+        }];
 }
 
 RCT_EXPORT_METHOD(resetImage:(nonnull NSNumber *)reactTag) {
-	dispatch_async(dispatch_get_main_queue(), ^{
-		[self.signView erase];
-	});
-}
-
--(void) publishSaveImageEvent:(NSString *) aTempPath withEncoded: (NSString *) aEncoded {
-	[self.bridge.eventDispatcher
-	 sendDeviceEventWithName:@"onSaveEvent"
-	 body:@{
-					@"pathName": aTempPath,
-					@"encoded": aEncoded
-					}];
-}
-
--(void) publishDraggedEvent {
-	[self.bridge.eventDispatcher
-	 sendDeviceEventWithName:@"onDragEvent"
-	 body:@{@"dragged": @YES}];
+        [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+          RSSignatureView *view = viewRegistry[reactTag];
+          [view erase];
+        }];
 }
 
 @end


### PR DESCRIPTION
Previously, Android used events that were targeted at the specific component whereas iOS used a globally broadcasted event via DeviceEventEmitter. This caused issues when trying to use multiple signature pads per page as a single event (onDragEvent for example) was broadcasted and picked up by both components. This caused issues when I was trying to validate which signature pads actually had a signature because both of their onDragEvents would fire when I signed only the first pad.

Also, when saving, the second signature would override the first for the same reasons.

This eliminates the need for the similar logic in both `onChange` and `componentDidMount` and creates a more consistent event architecture between iOS/Android implementations

This builds off of the work done in #83