### PR TITLE
Prevent clearing of signature image on save event

### DIFF
--- a/ios/PPSSignatureView.m
+++ b/ios/PPSSignatureView.m
@@ -293,7 +293,6 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 	
 	UIImage *signatureImg;
 	UIImage *snapshot = [self snapshot];
-	[self erase];
 	
 	if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ) {
 		//signature


### PR DESCRIPTION
Hello,

First, I'd like to say thank you for taking the time to create this project. I am having the same issue that the user who created issue #72 had. Whenever I trigger the save event (`saveImage`), the signature image disappears on iOS devices. This appears to me as a bug; if the image disappears after confirmation, it will appear to a user as "lost". In addition, if we really needed the signature to clear after saving, we can just call `resetImage` manually, which renders this behavior unneeded.

I have made a small change which fixes this issue, and tested it as well. It would be great if you can merge this in.

Thanks!