### PR TITLE
bugfix of RSSignatureCaptureMainView.java:47 Activity.getRequestedOri…

### DIFF
--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureViewManager.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureViewManager.java
@@ -110,7 +110,7 @@ public class RSSignatureCaptureViewManager extends ViewGroupManager<RSSignatureC
 	@Override
 	public RSSignatureCaptureMainView createViewInstance(ThemedReactContext context) {
 		Log.d("React"," View manager createViewInstance:");
-		return new RSSignatureCaptureMainView(context, mContextModule.getActivity());
+		return new RSSignatureCaptureMainView(context, context.getCurrentActivity());
 	}
 
 	@Override


### PR DESCRIPTION
bugfix of RSSignatureCaptureMainView.java:47 Activity.getRequestedOrientation on a null object reference

About app jump to another app, mContextModule.getActivity() will return null sometimes when back to our app, use ThemedReactContext could resolve this problem