### PR TITLE
getViewManagerConfig() replaces UIManager.RSSignatureView

### DIFF
--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -74,7 +74,7 @@ class SignatureCapture extends React.Component {
     saveImage() {
         UIManager.dispatchViewManagerCommand(
             ReactNative.findNodeHandle(this),
-            UIManager.RSSignatureView.Commands.saveImage,
+            UIManager.getViewManagerConfig('RSSignatureView').Commands.saveImage,
             [],
         );
     }
@@ -82,7 +82,7 @@ class SignatureCapture extends React.Component {
     resetImage() {
         UIManager.dispatchViewManagerCommand(
             ReactNative.findNodeHandle(this),
-            UIManager.RSSignatureView.Commands.resetImage,
+            UIManager.getViewManagerConfig('RSSignatureView').Commands.resetImage,
             [],
         );
     }


### PR DESCRIPTION
UIManager no longer supports direct referencing of objects via UIManager.RSSignatureView. ...
The suggestion was to use getViewManagerConfig to avoid UIManager['...'] warning

refactored UIManager.RSSignatureView to UIManager.getViewMangerConfig('RSSignatureView') in SignatureCapture.js - saveImage() && resetImage()

tested googlePixel 2 xl and nexus 6 emulator.
Works as expected and no warning