### PR TITLE
change obsolete 'compile' to 'implementation'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.0.0'
-    compile 'com.facebook.react:react-native:0.19.+'
+    implementation 'com.android.support:appcompat-v7:23.0.0'
+    implementation 'com.facebook.react:react-native:0.19.+'
 }


### PR DESCRIPTION
## Why
Getting warning during gradle sync:
>WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html

## Changes
- change `compile` to `implementation` to get rid of warnings when syncing parent apps