### PR TITLE
Add support for dots to Android

### DIFF
--- a/android/android.iml
+++ b/android/android.iml
@@ -6,13 +6,9 @@
         <option name="GRADLE_PROJECT_PATH" value=":" />
       </configuration>
     </facet>
-    <facet type="android" name="Android">
-      <configuration>
-        <option name="ALLOW_USER_CONFIGURATION" value="false" />
-      </configuration>
-    </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/android/android.iml
+++ b/android/android.iml
@@ -6,9 +6,13 @@
         <option name="GRADLE_PROJECT_PATH" value=":" />
       </configuration>
     </facet>
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="ALLOW_USER_CONFIGURATION" value="false" />
+      </configuration>
+    </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
@@ -101,7 +101,7 @@ public class RSSignatureCaptureMainView extends LinearLayout implements OnClickL
 
     // set orientation
     linearLayout.setOrientation(LinearLayout.HORIZONTAL);
-    linearLayout.setBackgroundColor(Color.parseColor("#f7f7fa");
+    linearLayout.setBackgroundColor(Color.parseColor("#f7f7fa"));
 
     // set texts, tags and OnClickListener
     saveBtn.setText("Save");

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
@@ -56,7 +56,7 @@ public class RSSignatureCaptureMainView extends LinearLayout implements OnClickL
     this.addView(signatureView);
 
     setLayoutParams(new android.view.ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-        ViewGroup.LayoutParams.MATCH_PARENT));
+            ViewGroup.LayoutParams.MATCH_PARENT));
   }
 
   public RSSignatureCaptureView getSignatureView() {
@@ -101,7 +101,7 @@ public class RSSignatureCaptureMainView extends LinearLayout implements OnClickL
 
     // set orientation
     linearLayout.setOrientation(LinearLayout.HORIZONTAL);
-    linearLayout.setBackgroundColor(Color.parseColor("#f7f7fa"));
+    linearLayout.setBackgroundColor(Color.TRANSPARENT);
 
     // set texts, tags and OnClickListener
     saveBtn.setText("Save");

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
@@ -101,7 +101,7 @@ public class RSSignatureCaptureMainView extends LinearLayout implements OnClickL
 
     // set orientation
     linearLayout.setOrientation(LinearLayout.HORIZONTAL);
-    linearLayout.setBackgroundColor(Color.WHITE);
+    linearLayout.setBackgroundColor(Color.parseColor("#f7f7fa");
 
     // set texts, tags and OnClickListener
     saveBtn.setText("Save");

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -153,6 +153,11 @@ public class RSSignatureCaptureView extends View {
 			// Remove the first element from the list,
 			// so that we always have no more than 4 mPoints in mPoints array.
 			mPoints.remove(0);
+		} else if (mPoints.size() == 1){
+			ensureSignatureBitmap();
+			mPaint.setStrokeWidth(mLastWidth);
+			mSignatureBitmapCanvas.drawPoint(newPoint.x, newPoint.y, mPaint);
+			expandDirtyRect(newPoint.x, newPoint.y);
 		}
 	}
 

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -20,6 +20,7 @@ import android.util.DisplayMetrics;
 
 import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,8 +70,8 @@ public class RSSignatureCaptureView extends View {
 		mPaint.setStrokeCap(Paint.Cap.ROUND);
 		mPaint.setStrokeJoin(Paint.Join.ROUND);
 
-		mMinWidth = convertDpToPx(6);
-		mMaxWidth = convertDpToPx(14);
+		mMinWidth = convertDpToPx(4);
+		mMaxWidth = convertDpToPx(10);
 		mVelocityFilterWeight = 0.4f;
 		mPaint.setColor(Color.BLACK);
 
@@ -87,10 +88,10 @@ public class RSSignatureCaptureView extends View {
 	}
 
 	/**
-	* Get signature
-	*
-	* @return
-	*/
+	 * Get signature
+	 *
+	 * @return
+	 */
 	public Bitmap getSignature() {
 
 		Bitmap signatureBitmap = null;
@@ -109,8 +110,8 @@ public class RSSignatureCaptureView extends View {
 
 
 	/**
-	* clear signature canvas
-	*/
+	 * clear signature canvas
+	 */
 	public void clearSignature() {
 		clear();
 	}
@@ -155,6 +156,14 @@ public class RSSignatureCaptureView extends View {
 			mPoints.remove(0);
 		} else if (mPoints.size() == 1){
 			ensureSignatureBitmap();
+
+//			float velocity = mVelocityFilterWeight * mLastVelocity
+//					+ (1 - mVelocityFilterWeight) * mLastVelocity;
+//
+//			// The new width is a function of the velocity. Higher velocities
+//			// correspond to thinner strokes.
+//			float newWidth = strokeWidth(velocity);
+
 			mPaint.setStrokeWidth(mLastWidth);
 			mSignatureBitmapCanvas.drawPoint(newPoint.x, newPoint.y, mPaint);
 			expandDirtyRect(newPoint.x, newPoint.y);
@@ -245,7 +254,7 @@ public class RSSignatureCaptureView extends View {
 	@Override
 	public boolean onTouchEvent(MotionEvent event) {
 		if (!isEnabled() || event.getPointerCount() > 1 || (multipleTouchDragged && event.getAction() != MotionEvent.ACTION_UP)) {
-		    multipleTouchDragged = true;
+			multipleTouchDragged = true;
 			return false;
 		}
 
@@ -254,32 +263,32 @@ public class RSSignatureCaptureView extends View {
 
 		switch (event.getAction()) {
 			case MotionEvent.ACTION_DOWN:
-                mLastTouchX = eventX;
-                mLastTouchY = eventY;
+				mLastTouchX = eventX;
+				mLastTouchY = eventY;
 				getParent().requestDisallowInterceptTouchEvent(true);
 				mPoints.clear();
 				mPath.moveTo(eventX, eventY);
 				addPoint(new TimedPoint(eventX, eventY));
 
 			case MotionEvent.ACTION_MOVE:
-                if((Math.abs(mLastTouchX - eventX) < SCROLL_THRESHOLD || Math.abs(mLastTouchY - eventY) < SCROLL_THRESHOLD) && dragged) {
-                    return false;
-                }
+				if((Math.abs(mLastTouchX - eventX) < SCROLL_THRESHOLD || Math.abs(mLastTouchY - eventY) < SCROLL_THRESHOLD) && dragged) {
+					return false;
+				}
 				resetDirtyRect(eventX, eventY);
 				addPoint(new TimedPoint(eventX, eventY));
-                dragged = true;
+				dragged = true;
 				break;
 
 			case MotionEvent.ACTION_UP:
-			    if(mPoints.size() >= 3) {
-                    resetDirtyRect(eventX, eventY);
-                    addPoint(new TimedPoint(eventX, eventY));
-                    getParent().requestDisallowInterceptTouchEvent(true);
-                    setIsEmpty(false);
-                    sendDragEventToReact();
-			    }
-                dragged = false;
-                multipleTouchDragged = false;
+				if(mPoints.size() >= 3) {
+					resetDirtyRect(eventX, eventY);
+					addPoint(new TimedPoint(eventX, eventY));
+					getParent().requestDisallowInterceptTouchEvent(true);
+					setIsEmpty(false);
+					sendDragEventToReact();
+				}
+				dragged = false;
+				multipleTouchDragged = false;
 				break;
 
 			default:
@@ -361,8 +370,8 @@ public class RSSignatureCaptureView extends View {
 	public void clear() {
 		dragged = false;
 		mPoints = new ArrayList<TimedPoint>();
-		mLastVelocity = 0;
-		mLastWidth = (mMinWidth + mMaxWidth) / 2;
+		mLastVelocity = 3;
+		mLastWidth =  strokeWidth(mLastVelocity);
 		mPath.reset();
 
 		if (mSignatureBitmap != null) {

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -69,8 +69,8 @@ public class RSSignatureCaptureView extends View {
 		mPaint.setStrokeCap(Paint.Cap.ROUND);
 		mPaint.setStrokeJoin(Paint.Join.ROUND);
 
-		mMinWidth = convertDpToPx(8);
-		mMaxWidth = convertDpToPx(16);
+		mMinWidth = convertDpToPx(6);
+		mMaxWidth = convertDpToPx(14);
 		mVelocityFilterWeight = 0.4f;
 		mPaint.setColor(Color.BLACK);
 

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -70,8 +70,8 @@ public class RSSignatureCaptureView extends View {
 		mPaint.setStrokeCap(Paint.Cap.ROUND);
 		mPaint.setStrokeJoin(Paint.Join.ROUND);
 
-		mMinWidth = convertDpToPx(4);
-		mMaxWidth = convertDpToPx(10);
+		mMinWidth = convertDpToPx(5);
+		mMaxWidth = convertDpToPx(11);
 		mVelocityFilterWeight = 0.4f;
 		mPaint.setColor(Color.BLACK);
 

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -81,7 +81,7 @@ public class RSSignatureCaptureView extends View {
 		clear();
 
 		// set the bg color
-		this.setBackgroundColor(Color.parseColor("#f7f7fa"));
+		this.setBackgroundColor(Color.TRANSPARENT);
 
 		// width and height should cover the screen
 		this.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
@@ -98,7 +98,7 @@ public class RSSignatureCaptureView extends View {
 
 		// set the signature bitmap
 		if (signatureBitmap == null) {
-			signatureBitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(), Bitmap.Config.RGB_565);
+			signatureBitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(), Bitmap.Config.ARGB_4444 );
 		}
 
 		// important for saving signature

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -269,6 +269,7 @@ public class RSSignatureCaptureView extends View {
 				mPoints.clear();
 				mPath.moveTo(eventX, eventY);
 				addPoint(new TimedPoint(eventX, eventY));
+				break;
 
 			case MotionEvent.ACTION_MOVE:
 				if((Math.abs(mLastTouchX - eventX) < SCROLL_THRESHOLD || Math.abs(mLastTouchY - eventY) < SCROLL_THRESHOLD) && dragged) {

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -79,8 +79,8 @@ public class RSSignatureCaptureView extends View {
 
 		clear();
 
-		// set the bg color as white
-		this.setBackgroundColor(Color.WHITE);
+		// set the bg color
+		this.setBackgroundColor(Color.parseColor("#f7f7fa"));
 
 		// width and height should cover the screen
 		this.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));

--- a/ios/PPSSignatureView.m
+++ b/ios/PPSSignatureView.m
@@ -124,10 +124,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 		time(NULL);
 
-        self.backgroundColor = [UIColor colorWithRed:247.0f/255.0f
-                                               green:247.0f/255.0f
-                                                blue:250.0f/255.0f
-                                               alpha:1.0f];
+        self.backgroundColor = [UIColor clearColor];
 		self.opaque = NO;
 
 		self.context = context;
@@ -296,7 +293,6 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 	UIImage *signatureImg;
 	UIImage *snapshot = [self snapshot];
-	[self erase];
 
 	if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ) {
 		//signature

--- a/ios/PPSSignatureView.m
+++ b/ios/PPSSignatureView.m
@@ -35,11 +35,11 @@ static inline void addVertex(uint *length, PPSSignaturePoint v) {
 	if ((*length) >= maxLength) {
 		return;
 	}
-	
+
 	GLvoid *data = glMapBufferOES(GL_ARRAY_BUFFER, GL_WRITE_ONLY_OES);
 	memcpy(data + sizeof(PPSSignaturePoint) * (*length), &v, sizeof(PPSSignaturePoint));
 	glUnmapBufferOES(GL_ARRAY_BUFFER);
-	
+
 	(*length)++;
 }
 
@@ -47,7 +47,7 @@ static inline CGPoint QuadraticPointInCurve(CGPoint start, CGPoint end, CGPoint 
 	double a = pow((1.0 - percent), 2.0);
 	double b = 2.0 * percent * (1.0 - percent);
 	double c = pow(percent, 2.0);
-	
+
 	return (CGPoint) {
 		a * start.x + b * controlPoint.x + c * end.x,
 		a * start.y + b * controlPoint.y + c * end.y
@@ -68,7 +68,7 @@ static GLKVector3 perpendicular(PPSSignaturePoint p1, PPSSignaturePoint p2) {
 }
 
 static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVector3 color) {
-	
+
 	return (PPSSignaturePoint) {
 		{
 			(viewPoint.x / bounds.size.width * 2.0 - 1),
@@ -84,26 +84,26 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 	// OpenGL state
 	EAGLContext *context;
 	GLKBaseEffect *effect;
-	
+
 	GLuint vertexArray;
 	GLuint vertexBuffer;
 	GLuint dotsArray;
 	GLuint dotsBuffer;
-	
-	
+
+
 	// Array of verteces, with current length
 	PPSSignaturePoint SignatureVertexData[maxLength];
 	uint length;
-	
+
 	PPSSignaturePoint SignatureDotsData[maxLength];
 	uint dotsLength;
-	
-	
+
+
 	// Width of line at current and previous vertex
 	float penThickness;
 	float previousThickness;
-	
-	
+
+
 	// Previous points for quadratic bezier computations
 	CGPoint previousPoint;
 	CGPoint previousMidPoint;
@@ -119,34 +119,37 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)commonInit {
 	context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
-	
+
 	if (context) {
-		
+
 		time(NULL);
-		
-		self.backgroundColor = [UIColor whiteColor];
+
+        self.backgroundColor = [UIColor colorWithRed:247.0f/255.0f
+                                               green:247.0f/255.0f
+                                                blue:250.0f/255.0f
+                                               alpha:1.0f];
 		self.opaque = NO;
-		
+
 		self.context = context;
 		self.drawableDepthFormat = GLKViewDrawableDepthFormat24;
 		self.enableSetNeedsDisplay = YES;
-		
+
 		// Turn on antialiasing
 		self.drawableMultisample = GLKViewDrawableMultisample4X;
-		
+
 		[self setupGL];
-		
+
 		// Capture touches
 		UIPanGestureRecognizer *pan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(pan:)];
 		pan.maximumNumberOfTouches = pan.minimumNumberOfTouches = 1;
 		pan.cancelsTouchesInView = YES;
 		[self addGestureRecognizer:pan];
-		
+
 		// For dotting your i's
 		UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tap:)];
 		tap.cancelsTouchesInView = YES;
 		[self addGestureRecognizer:tap];
-		
+
 		// Erase with long press
 		UILongPressGestureRecognizer *longer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longPress:)];
 		longer.cancelsTouchesInView = YES;
@@ -175,11 +178,11 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 {
 	self.context = nil;
 	[self tearDownGL];
-	
+
 	if ([EAGLContext currentContext] == context) {
 		[EAGLContext setCurrentContext:nil];
 	}
-	
+
 	context = nil;
 }
 
@@ -188,15 +191,15 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 {
 	glClearColor(clearColor[0], clearColor[1], clearColor[2], clearColor[3]);
 	glClear(GL_COLOR_BUFFER_BIT);
-	
+
 	[effect prepareToDraw];
-	
+
 	// Drawing of signature lines
 	if (length > 2) {
 		glBindVertexArrayOES(vertexArray);
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, length);
 	}
-	
+
 	if (dotsLength > 0) {
 		glBindVertexArrayOES(dotsArray);
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, dotsLength);
@@ -207,13 +210,13 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 	length = 0;
 	dotsLength = 0;
 	self.hasSignature = NO;
-	
+
 	[self setNeedsDisplay];
 }
 
 - (UIImage*)imageByCombiningImage:(UIImage*)firstImage withImage:(UIImage*)secondImage {
 	UIImage *image = nil;
-	
+
 	CGSize newImageSize = CGSizeMake(MAX(firstImage.size.width, secondImage.size.width), MAX(firstImage.size.height, secondImage.size.height));
 	if (UIGraphicsBeginImageContextWithOptions != NULL) {
 		UIGraphicsBeginImageContextWithOptions(newImageSize, NO, [[UIScreen mainScreen] scale]);
@@ -226,7 +229,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 																			 roundf((newImageSize.height-secondImage.size.height)/2))];
 	image = UIGraphicsGetImageFromCurrentImageContext();
 	UIGraphicsEndImageContext();
-	
+
 	return image;
 }
 
@@ -244,17 +247,17 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 											 scale:1.0
 								 orientation:clockwise ? UIImageOrientationRight : UIImageOrientationLeft]
 	 drawInRect:CGRectMake(0,0,size.height ,size.width)];
-	
+
 	UIImage* newImage = UIGraphicsGetImageFromCurrentImageContext();
 	UIGraphicsEndImageContext();
-	
+
 	return newImage;
 }
 
 - (UIImage*) reduceImage:(UIImage*)image toSize:(CGSize)newSize {
 	CGSize scaledSize = newSize;
 	float scaleFactor = 1.0;
-	
+
 	if(image.size.width > image.size.height) {
 		scaleFactor = image.size.width / image.size.height;
 		scaledSize.width = newSize.width;
@@ -265,16 +268,16 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 		scaledSize.height = newSize.height;
 		scaledSize.width = newSize.width / scaleFactor;
 	}
-	
+
 	NSLog(@"%f x %f", scaledSize.width, scaledSize.height);
-	
+
 	UIGraphicsBeginImageContext(scaledSize);
 	CGRect scaledImageRect = CGRectMake( 0.0, 0.0, scaledSize.width, scaledSize.height );
 	[image drawInRect:scaledImageRect];
-	
+
 	UIImage* scaledImage = UIGraphicsGetImageFromCurrentImageContext();
 	UIGraphicsEndImageContext();
-	
+
 	return scaledImage;
 }
 
@@ -290,11 +293,11 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 {
 	if (!self.hasSignature)
 		return nil;
-	
+
 	UIImage *signatureImg;
 	UIImage *snapshot = [self snapshot];
 	[self erase];
-	
+
 	if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ) {
 		//signature
 		if (square) {
@@ -306,7 +309,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 	}
 	else {
 		//rotate iphone signature - iphone's signature screen is always landscape
-		
+
 		if (rotatedImage) {
 			if (square) {
 				UIImage *rotatedImg = [self rotateImage:snapshot clockwise:false];
@@ -326,7 +329,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 			}
 		}
 	}
-	
+
 	return signatureImg;
 }
 
@@ -336,17 +339,17 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)tap:(UITapGestureRecognizer *)t {
 	CGPoint l = [t locationInView:self];
-	
+
 	if (t.state == UIGestureRecognizerStateRecognized) {
 		glBindBuffer(GL_ARRAY_BUFFER, dotsBuffer);
-		
+
 		PPSSignaturePoint touchPoint = ViewPointToGL(l, self.bounds, (GLKVector3){1, 1, 1});
 		addVertex(&dotsLength, touchPoint);
-		
+
 		PPSSignaturePoint centerPoint = touchPoint;
 		centerPoint.color = StrokeColor;
 		addVertex(&dotsLength, centerPoint);
-		
+
 		static int segments = 20;
 		GLKVector2 radius = (GLKVector2){
 			clamp(0.00001, 0.02, penThickness * generateRandom(0.5, 1.5)),
@@ -354,24 +357,24 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 		};
 		GLKVector2 velocityRadius = radius;
 		float angle = 0;
-		
+
 		for (int i = 0; i <= segments; i++) {
-			
+
 			PPSSignaturePoint p = centerPoint;
 			p.vertex.x += velocityRadius.x * cosf(angle);
 			p.vertex.y += velocityRadius.y * sinf(angle);
-			
+
 			addVertex(&dotsLength, p);
 			addVertex(&dotsLength, centerPoint);
-			
+
 			angle += M_PI * 2.0 / segments;
 		}
-		
+
 		addVertex(&dotsLength, touchPoint);
-		
+
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
 	}
-	
+
 	[self setNeedsDisplay];
 }
 
@@ -381,87 +384,87 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 }
 
 - (void)pan:(UIPanGestureRecognizer *)p {
-	
+
 	glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
-	
+
 	CGPoint v = [p velocityInView:self];
 	CGPoint l = [p locationInView:self];
-	
+
 	currentVelocity = ViewPointToGL(v, self.bounds, (GLKVector3){0,0,0});
 	float distance = 0.;
 	if (previousPoint.x > 0) {
 		distance = sqrtf((l.x - previousPoint.x) * (l.x - previousPoint.x) + (l.y - previousPoint.y) * (l.y - previousPoint.y));
 	}
-	
+
 	float velocityMagnitude = sqrtf(v.x*v.x + v.y*v.y);
 	float clampedVelocityMagnitude = clamp(VELOCITY_CLAMP_MIN, VELOCITY_CLAMP_MAX, velocityMagnitude);
 	float normalizedVelocity = (clampedVelocityMagnitude - VELOCITY_CLAMP_MIN) / (VELOCITY_CLAMP_MAX - VELOCITY_CLAMP_MIN);
-	
+
 	float lowPassFilterAlpha = STROKE_WIDTH_SMOOTHING;
 	float newThickness = (STROKE_WIDTH_MAX - STROKE_WIDTH_MIN) * (1 - normalizedVelocity) + STROKE_WIDTH_MIN;
 	penThickness = penThickness * lowPassFilterAlpha + newThickness * (1 - lowPassFilterAlpha);
-	
+
 	if ([p state] == UIGestureRecognizerStateBegan) {
-		
+
 		previousPoint = l;
 		previousMidPoint = l;
-		
+
 		PPSSignaturePoint startPoint = ViewPointToGL(l, self.bounds, (GLKVector3){1, 1, 1});
 		previousVertex = startPoint;
 		previousThickness = penThickness;
-		
+
 		addVertex(&length, startPoint);
 		addVertex(&length, previousVertex);
-		
+
 		self.hasSignature = YES;
 		[self.manager publishDraggedEvent];
-		
+
 	} else if ([p state] == UIGestureRecognizerStateChanged) {
-		
+
 		CGPoint mid = CGPointMake((l.x + previousPoint.x) / 2.0, (l.y + previousPoint.y) / 2.0);
-		
+
 		if (distance > QUADRATIC_DISTANCE_TOLERANCE) {
 			// Plot quadratic bezier instead of line
 			unsigned int i;
-			
+
 			int segments = (int) distance / 1.5;
-			
+
 			float startPenThickness = previousThickness;
 			float endPenThickness = penThickness;
 			previousThickness = penThickness;
-			
+
 			for (i = 0; i < segments; i++)
 			{
 				penThickness = startPenThickness + ((endPenThickness - startPenThickness) / segments) * i;
-				
+
 				CGPoint quadPoint = QuadraticPointInCurve(previousMidPoint, mid, previousPoint, (float)i / (float)(segments));
-				
+
 				PPSSignaturePoint v = ViewPointToGL(quadPoint, self.bounds, StrokeColor);
 				[self addTriangleStripPointsForPrevious:previousVertex next:v];
-				
+
 				previousVertex = v;
 			}
 		} else if (distance > 1.0) {
-			
+
 			PPSSignaturePoint v = ViewPointToGL(l, self.bounds, StrokeColor);
 			[self addTriangleStripPointsForPrevious:previousVertex next:v];
-			
+
 			previousVertex = v;
 			previousThickness = penThickness;
 		}
-		
+
 		previousPoint = l;
 		previousMidPoint = mid;
-		
+
 	} else if (p.state == UIGestureRecognizerStateEnded | p.state == UIGestureRecognizerStateCancelled) {
-		
+
 		PPSSignaturePoint v = ViewPointToGL(l, self.bounds, (GLKVector3){1, 1, 1});
 		addVertex(&length, v);
-		
+
 		previousVertex = v;
 		addVertex(&length, previousVertex);
 	}
-	
+
 	[self setNeedsDisplay];
 }
 
@@ -486,7 +489,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor {
 	[super setBackgroundColor:backgroundColor];
-	
+
 	CGFloat red, green, blue, alpha, white;
 	if ([backgroundColor getRed:&red green:&green blue:&blue alpha:&alpha]) {
 		clearColor[0] = red;
@@ -509,44 +512,44 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 - (void)setupGL
 {
 	[EAGLContext setCurrentContext:context];
-	
+
 	effect = [[GLKBaseEffect alloc] init];
-	
+
 	[self updateStrokeColor];
-	
-	
+
+
 	glDisable(GL_DEPTH_TEST);
-	
+
 	// Signature Lines
 	glGenVertexArraysOES(1, &vertexArray);
 	glBindVertexArrayOES(vertexArray);
-	
+
 	glGenBuffers(1, &vertexBuffer);
 	glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
 	glBufferData(GL_ARRAY_BUFFER, sizeof(SignatureVertexData), SignatureVertexData, GL_DYNAMIC_DRAW);
 	[self bindShaderAttributes];
-	
-	
+
+
 	// Signature Dots
 	glGenVertexArraysOES(1, &dotsArray);
 	glBindVertexArrayOES(dotsArray);
-	
+
 	glGenBuffers(1, &dotsBuffer);
 	glBindBuffer(GL_ARRAY_BUFFER, dotsBuffer);
 	glBufferData(GL_ARRAY_BUFFER, sizeof(SignatureDotsData), SignatureDotsData, GL_DYNAMIC_DRAW);
 	[self bindShaderAttributes];
-	
-	
+
+
 	glBindVertexArrayOES(0);
-	
-	
+
+
 	// Perspective
 	GLKMatrix4 ortho = GLKMatrix4MakeOrtho(-1, 1, -1, 1, 0.1f, 2.0f);
 	effect.transform.projectionMatrix = ortho;
-	
+
 	GLKMatrix4 modelViewMatrix = GLKMatrix4MakeTranslation(0.0f, 0.0f, -1.0f);
 	effect.transform.modelviewMatrix = modelViewMatrix;
-	
+
 	length = 0;
 	penThickness = 0.003;
 	previousPoint = CGPointMake(-100, -100);
@@ -556,26 +559,26 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)addTriangleStripPointsForPrevious:(PPSSignaturePoint)previous next:(PPSSignaturePoint)next {
 	float toTravel = penThickness / 2.0;
-	
+
 	for (int i = 0; i < 2; i++) {
 		GLKVector3 p = perpendicular(previous, next);
 		GLKVector3 p1 = next.vertex;
 		GLKVector3 ref = GLKVector3Add(p1, p);
-		
+
 		float distance = GLKVector3Distance(p1, ref);
 		float difX = p1.x - ref.x;
 		float difY = p1.y - ref.y;
 		float ratio = -1.0 * (toTravel / distance);
-		
+
 		difX = difX * ratio;
 		difY = difY * ratio;
-		
+
 		PPSSignaturePoint stripPoint = {
 			{ p1.x + difX, p1.y + difY, 0.0 },
 			StrokeColor
 		};
 		addVertex(&length, stripPoint);
-		
+
 		toTravel *= -1;
 	}
 }
@@ -584,13 +587,13 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 - (void)tearDownGL
 {
 	[EAGLContext setCurrentContext:context];
-	
+
 	glDeleteVertexArraysOES(1, &vertexArray);
 	glDeleteBuffers(1, &vertexBuffer);
-	
+
 	glDeleteVertexArraysOES(1, &dotsArray);
 	glDeleteBuffers(1, &dotsBuffer);
-	
+
 	effect = nil;
 }
 

--- a/ios/RSSignatureView.m
+++ b/ios/RSSignatureView.m
@@ -26,7 +26,7 @@
 
 - (instancetype)init
 {
-  _showBorder = YES;
+  _showBorder = NO;
 	_showNativeButtons = YES;
 	_showTitleLabel = YES;
 	if ((self = [super init])) {

--- a/react-native-signature-capture.podspec
+++ b/react-native-signature-capture.podspec
@@ -1,0 +1,16 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = "react-native-signature-capture"
+  s.version      = package["version"]
+  s.summary      = package["description"]
+  s.author       = package["author"]
+  s.homepage     = package["homepage"]
+  s.license      = package["license"]
+  s.platform     = :ios, "8.4"
+  s.source       = { :git => "https://github.com/RepairShopr/react-native-signature-capture", :tag => "#{s.version}" }
+  s.source_files  = "ios/*.{h,m}"
+  s.dependency "React"
+end


### PR DESCRIPTION
PR adds support for dots to Android version of the library. It checks if there is just one point available to draw (instead of more then 2) then it takes last stroke width recorded and draws that one point as a dot.