### PR TITLE
Add podspec file to be compatible with the latest RN 60

### DIFF
--- a/react-native-signature-capture.podspec
+++ b/react-native-signature-capture.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.homepage     = package["homepage"]
   s.license      = package["license"]
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/crazycodeboy/react-native-splash-screen", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/RepairShopr/react-native-signature-capture", :tag => "v#{s.version}" }
   s.source_files  = "ios/*.{h,m}"
   s.dependency "React"
 end

--- a/react-native-signature-capture.podspec
+++ b/react-native-signature-capture.podspec
@@ -1,0 +1,16 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = "react-native-signature-capture"
+  s.version      = package["version"]
+  s.summary      = package["description"]
+  s.author       = package["author"]
+  s.homepage     = package["homepage"]
+  s.license      = package["license"]
+  s.platform     = :ios, "7.0"
+  s.source       = { :git => "https://github.com/crazycodeboy/react-native-splash-screen", :tag => "v#{s.version}" }
+  s.source_files  = "ios/*.{h,m}"
+  s.dependency "React"
+end


### PR DESCRIPTION
Add podspec file to be compatible with the latest RN 60. This file is required to be compatible with auto-linking feature of RN 60+.

Without this file RN throws an error iOS:
 
![s](https://cdn-std.dprcdn.net/files/acc_752863/HL4eFk)

Resolves: #180 #142 

Could you apply this PR?