### PR TITLE
Add lintOptions to prevent crash at gradlew check

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,6 +17,9 @@ android {
             abiFilters "armeabi-v7a", "x86"
         }
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Lint found errors in the project; aborting build.
  
  Fix the issues identified by lint, or add the following to your build script to proceed with errors:
  ...
  android {
      lintOptions {
          abortOnError false
      }
  }
  ...

If it's possible, please update SDK version; this is what I currently have on a fork (I use RN 0.60.5):

compileSdkVersion safeExtGet('compileSdkVersion', 26)
buildToolsVersion safeExtGet('buildToolsVersion', "26.0.0")
minSdkVersion safeExtGet('minSdkVersion', 16)
targetSdkVersion safeExtGet('targetSdkVersion', 26)