### PR TITLE
Fix Issue #198; UIManager.getViewManagerConfig('RSSignatureView').Commands not longer supportet

### DIFF
--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -74,7 +74,7 @@ class SignatureCapture extends React.Component {
     saveImage() {
         UIManager.dispatchViewManagerCommand(
             ReactNative.findNodeHandle(this),
-            UIManager.getViewManagerConfig('RSSignatureView').Commands.saveImage,
+            UIManager.RSSignatureView.Commands.saveImage,
             [],
         );
     }
@@ -82,7 +82,7 @@ class SignatureCapture extends React.Component {
     resetImage() {
         UIManager.dispatchViewManagerCommand(
             ReactNative.findNodeHandle(this),
-            UIManager.getViewManagerConfig('RSSignatureView').Commands.resetImage,
+            UIManager.RSSignatureView.Commands.resetImage,
             [],
         );
     }


### PR DESCRIPTION
It works better with current RN version

```
    "react": "16.8.1",
    "react-native": "0.57.8",
```

Thank you