### PR TITLE
Allow stroke+background colors to be set on iOS+Android

### DIFF
--- a/Example/src/SignatureView.js
+++ b/Example/src/SignatureView.js
@@ -49,9 +49,10 @@ class SignatureView extends Component {
             </View>
           </View>
           <SignatureCapture
-              style={{flex: 1, width: '100%'}}
+            style={{flex: 1, width: '100%'}}
             onDragEvent={this._onDragEvent.bind(this)}
             onSaveEvent={this._onSaveEvent.bind(this)}
+            backgroundColor='pink'
           />
         </View>
       </Modal>

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ class CustomComponent extends Component {
 
 + **backgroundColor**: Sets the background color of the component. Defaults to white. May be 'transparent'.
 
++ **strokeColor**: Sets the color of the signature. Defaults to black.
+
 ### Methods
 
 + **saveImage()** : when called it will save the image and returns the base 64 encoded string on onSaveEvent() callback
@@ -165,6 +167,7 @@ class RNSignatureExample extends Component {
                     showNativeButtons={false}
                     showTitleLabel={false}
                     backgroundColor="#ff00ff"
+                    strokeColor="#ffffff"
                     viewMode={"portrait"}/>
 
                 <View style={{ flex: 1, flexDirection: "row" }}>

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ class CustomComponent extends Component {
 
 + **maxSize**  : sets the max size of the image maintains aspect ratio, default is 500
 
++ **backgroundColor**: Sets the background color of the component. Defaults to white. May be 'transparent'.
+
 ### Methods
 
 + **saveImage()** : when called it will save the image and returns the base 64 encoded string on onSaveEvent() callback
@@ -162,6 +164,7 @@ class RNSignatureExample extends Component {
                     saveImageFileInExtStorage={false}
                     showNativeButtons={false}
                     showTitleLabel={false}
+                    backgroundColor="#ff00ff"
                     viewMode={"portrait"}/>
 
                 <View style={{ flex: 1, flexDirection: "row" }}>

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
@@ -176,7 +176,7 @@ public class RSSignatureCaptureMainView extends LinearLayout implements OnClickL
 
 
       byte[] byteArray = byteArrayOutputStream.toByteArray();
-      String encoded = Base64.encodeToString(byteArray, Base64.DEFAULT);
+      String encoded = Base64.encodeToString(byteArray, Base64.NO_WRAP);
 
       WritableMap event = Arguments.createMap();
       event.putString("pathName", file.getAbsolutePath());

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -97,7 +97,7 @@ public class RSSignatureCaptureView extends View {
 
 		// set the signature bitmap
 		if (signatureBitmap == null) {
-			signatureBitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(), Bitmap.Config.RGB_565);
+			signatureBitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(), Bitmap.Config.ARGB_8888);
 		}
 
 		// important for saving signature

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureViewManager.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureViewManager.java
@@ -101,9 +101,16 @@ public class RSSignatureCaptureViewManager extends ViewGroupManager<RSSignatureC
 
 	@ReactProp(name = PROPS_BACKGROUND_COLOR)
 	public void setPropsBackgroundColor(RSSignatureCaptureMainView view, @Nullable String color) {
+		int parsed;
+		if (color.equalsIgnoreCase("transparent")) {
+			parsed = Color.TRANSPARENT;
+		} else {
+			parsed = Color.parseColor(color);
+		}
+
 		Log.d("backgroundColor:",  ""+color);
 		if(view!=null){
-			view.getSignatureView().setBackgroundColor(Color.parseColor(color));
+			view.getSignatureView().setBackgroundColor(parsed);
 		}
 	}
 

--- a/ios/PPSSignatureView.m
+++ b/ios/PPSSignatureView.m
@@ -110,6 +110,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 	PPSSignaturePoint previousVertex;
 	PPSSignaturePoint currentVelocity;
 	UIColor* backgroundColor;
+	UIColor* strokeColor;
 }
 
 @end
@@ -126,6 +127,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 		time(NULL);
 		
 		self.backgroundColor = [UIColor whiteColor];
+		self.strokeColor = [UIColor blackColor];
 		self.opaque = NO;
 		
 		self.context = context;

--- a/ios/PPSSignatureView.m
+++ b/ios/PPSSignatureView.m
@@ -109,6 +109,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 	CGPoint previousMidPoint;
 	PPSSignaturePoint previousVertex;
 	PPSSignaturePoint currentVelocity;
+	UIColor* backgroundColor;
 }
 
 @end

--- a/ios/RSSignatureView.m
+++ b/ios/RSSignatureView.m
@@ -19,6 +19,7 @@
 	BOOL _showBorder;
 	BOOL _showNativeButtons;
 	BOOL _showTitleLabel;
+	UIColor *_backgroundColor;
 }
 
 @synthesize sign;
@@ -26,9 +27,10 @@
 
 - (instancetype)init
 {
-  _showBorder = YES;
+	_showBorder = YES;
 	_showNativeButtons = YES;
 	_showTitleLabel = YES;
+	_backgroundColor = UIColor.whiteColor;
 	if ((self = [super init])) {
 		_border = [CAShapeLayer layer];
 		_border.strokeColor = [UIColor blackColor].CGColor;
@@ -65,6 +67,7 @@
 						initWithFrame: CGRectMake(0, 0, screen.width, screen.height)
 						context: _context];
 		sign.manager = manager;
+		sign.backgroundColor = _backgroundColor;
 
 		[self addSubview:sign];
 
@@ -177,6 +180,10 @@
 
 - (void)setShowTitleLabel:(BOOL)showTitleLabel {
 	_showTitleLabel = showTitleLabel;
+}
+
+- (void)setBackgroundColor:(UIColor*)backgroundColor {
+	_backgroundColor = backgroundColor;
 }
 
 -(void) onSaveButtonPressed {

--- a/ios/RSSignatureView.m
+++ b/ios/RSSignatureView.m
@@ -20,6 +20,7 @@
 	BOOL _showNativeButtons;
 	BOOL _showTitleLabel;
 	UIColor *_backgroundColor;
+	UIColor *_strokeColor;
 }
 
 @synthesize sign;
@@ -31,6 +32,7 @@
 	_showNativeButtons = YES;
 	_showTitleLabel = YES;
 	_backgroundColor = UIColor.whiteColor;
+	_strokeColor = UIColor.blackColor;
 	if ((self = [super init])) {
 		_border = [CAShapeLayer layer];
 		_border.strokeColor = [UIColor blackColor].CGColor;
@@ -68,6 +70,7 @@
 						context: _context];
 		sign.manager = manager;
 		sign.backgroundColor = _backgroundColor;
+		sign.strokeColor = _strokeColor;
 
 		[self addSubview:sign];
 
@@ -184,6 +187,10 @@
 
 - (void)setBackgroundColor:(UIColor*)backgroundColor {
 	_backgroundColor = backgroundColor;
+}
+
+- (void)setStrokeColor:(UIColor*)strokeColor {
+	_strokeColor = strokeColor;
 }
 
 -(void) onSaveButtonPressed {

--- a/ios/RSSignatureViewManager.m
+++ b/ios/RSSignatureViewManager.m
@@ -15,6 +15,7 @@ RCT_EXPORT_VIEW_PROPERTY(square, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showBorder, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showNativeButtons, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showTitleLabel, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
 
 
 -(dispatch_queue_t) methodQueue

--- a/ios/RSSignatureViewManager.m
+++ b/ios/RSSignatureViewManager.m
@@ -16,6 +16,7 @@ RCT_EXPORT_VIEW_PROPERTY(showBorder, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showNativeButtons, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showTitleLabel, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(strokeColor, UIColor)
 
 
 -(dispatch_queue_t) methodQueue


### PR DESCRIPTION
* Allow backgroundColor to be customized on iOS.
* Allow backgroundColor to be transparent in Android.
* Allow strokeColor to be changed on iOS.
* Remove line breaks from Android's base 64 encoding.