### PR TITLE
Added new prop clearSignOnOrientationChange

### DIFF
--- a/android/android.iml
+++ b/android/android.iml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
         <option name="GRADLE_PROJECT_PATH" value=":" />
-      </configuration>
-    </facet>
-    <facet type="android" name="Android">
-      <configuration>
-        <option name="ALLOW_USER_CONFIGURATION" value="false" />
+        <option name="LAST_SUCCESSFUL_SYNC_AGP_VERSION" />
+        <option name="LAST_KNOWN_AGP_VERSION" />
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,12 +5,12 @@ def safeExtGet(prop, fallback) {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 23)
-    buildToolsVersion safeExtGet('buildToolsVersion', "23.0.1")
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', "28.0.3")
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 22)
+        minSdkVersion safeExtGet('minSdkVersion', 19)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
         ndk {
@@ -20,6 +20,6 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '23.0.0')}"
+    implementation "androidx.appcompat:appcompat:1.0.0"
     implementation "com.facebook.react:react-native:+"
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier=true
+android.useAndroidX=true

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -69,10 +69,10 @@ public class RSSignatureCaptureView extends View {
 		mPaint.setStrokeCap(Paint.Cap.ROUND);
 		mPaint.setStrokeJoin(Paint.Join.ROUND);
 
-		mMinWidth = convertDpToPx(8);
-		mMaxWidth = convertDpToPx(16);
+		mMinWidth = convertDpToPx(4);
+		mMaxWidth = convertDpToPx(8);
 		mVelocityFilterWeight = 0.4f;
-		mPaint.setColor(Color.BLACK);
+		mPaint.setColor("#1d26b7");
 
 		//Dirty rectangle to update only the changed portion of the view
 		mDirtyRect = new RectF();
@@ -80,7 +80,7 @@ public class RSSignatureCaptureView extends View {
 		clear();
 
 		// set the bg color as white
-		this.setBackgroundColor(Color.WHITE);
+		this.setBackgroundColor(Color.TRANSPARENT);
 
 		// width and height should cover the screen
 		this.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
@@ -97,7 +97,7 @@ public class RSSignatureCaptureView extends View {
 
 		// set the signature bitmap
 		if (signatureBitmap == null) {
-			signatureBitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(), Bitmap.Config.RGB_565);
+			signatureBitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(), Bitmap.Config.ARGB_8888);
 		}
 
 		// important for saving signature

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -72,7 +72,7 @@ public class RSSignatureCaptureView extends View {
 		mMinWidth = convertDpToPx(4);
 		mMaxWidth = convertDpToPx(8);
 		mVelocityFilterWeight = 0.4f;
-		mPaint.setColor("#1d26b7");
+		mPaint.setColor(Color.parseColor("#1d26b7"));
 
 		//Dirty rectangle to update only the changed portion of the view
 		mDirtyRect = new RectF();

--- a/ios/PPSSignatureView.m
+++ b/ios/PPSSignatureView.m
@@ -293,7 +293,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 	
 	UIImage *signatureImg;
 	UIImage *snapshot = [self snapshot];
-	[self erase];
+// 	[self erase]; not required causing clear signature issue on submission
 	
 	if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ) {
 		//signature


### PR DESCRIPTION
Existing problem:

Right now if the mobilde device is rotated, the user can do the signature, user has to clear the signature and redo it
Added a new prop clearSignOnOrientationChange which will auotmatically clear the signature on orientation change from portrait to landscape and vice versa