### PR TITLE
Exclude "Example" directory when packaging

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -25,3 +25,6 @@ DerivedData
 
 # Pods
 Pods
+
+# The example app
+Example


### PR DESCRIPTION
This is by far the largest module in our app, weighing in at ~215MB in the node_modules folder.

Upon further inspection, it's because an entire RN app is included along with it in the "Example" directory, which isn't needed for install.

This PR adds the "Example" directory to the `.npmignore` file so it's not included in the published package.