### PR TITLE
Update build.gradle to provide namespace

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.63.2",
-    "react-native-signature-capture": "^0.4.11"
+    "rjc-react-native-signature-capture": "^0.4.12"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/Example/src/SignatureView.android.js
+++ b/Example/src/SignatureView.android.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {View, Text, Modal, Platform} from 'react-native';
-import SignatureCapture from 'react-native-signature-capture';
+import SignatureCapture from 'rjc-react-native-signature-capture';
 
 const toolbarHeight = Platform.select({
   android: 0,

--- a/Example/src/SignatureView.ios.js
+++ b/Example/src/SignatureView.ios.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {View, Text, Modal, Platform} from 'react-native';
-import SignatureCapture from 'react-native-signature-capture';
+import SignatureCapture from 'rjc-react-native-signature-capture';
 
 const toolbarHeight = Platform.select({
   android: 0,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# react-native-signature-capture
+# rjc-react-native-signature-capture
 
 ## About this
 React Native library for capturing signature
+This repository was forked from RepairShopr/react-native-signature-capture which appears to no longer be updated. This forked branch was created to extend the life of this library past APG 7 which required a namespace in the build.gradle file for Android devices. Below README is still for the original react-native-signature-capture repository.
 
 User would sign on the app and when you press the save button it returns the base64 encoded png
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,10 @@ def safeExtGet(prop, fallback) {
 apply plugin: 'com.android.library'
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace "com.rssignaturecapture"
+    }
     compileSdkVersion safeExtGet('compileSdkVersion', 23)
     buildToolsVersion safeExtGet('buildToolsVersion', "23.0.1")
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rjc-react-native-signature-capture",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Lets users sign their signatures",
   "main": "SignatureCapture.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-signature-capture",
-  "version": "0.4.11",
+  "name": "rjc-react-native-signature-capture",
+  "version": "0.4.12",
   "description": "Lets users sign their signatures",
   "main": "SignatureCapture.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/RepairShopr/react-native-signature-capture.git"
+    "url": "git+https://github.com/joel-chalkley-od/rjc-react-native-signature-capture.git"
   },
   "keywords": [
     "react-component",
@@ -22,9 +22,9 @@
   "author": "RepairShopr",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/RepairShopr/react-native-signature-capture/issues"
+    "url": "https://github.com/joel-chalkley-od/rjc-react-native-signature-capture/issues"
   },
-  "homepage": "https://github.com/RepairShopr/react-native-signature-capture#readme",
+  "homepage": "https://github.com/joel-chalkley-od/rjc-react-native-signature-capture#readme",
   "dependencies": {
     "prop-types": "^15.5.10"
   },

--- a/rjc-react-native-signature-capture.podspec
+++ b/rjc-react-native-signature-capture.podspec
@@ -3,14 +3,14 @@ require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
-  s.name         = "react-native-signature-capture"
+  s.name         = "rjc-react-native-signature-capture"
   s.version      = package["version"]
   s.summary      = package["description"]
   s.author       = package["author"]
   s.homepage     = package["homepage"]
   s.license      = package["license"]
   s.platform     = :ios, "8.4"
-  s.source       = { :git => "https://github.com/RepairShopr/react-native-signature-capture", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/joel-chalkley-od/rjc-react-native-signature-capture", :tag => "#{s.version}" }
   s.source_files  = "ios/*.{h,m}"
   s.dependency "React"
 end


### PR DESCRIPTION
All versions of Android Gradle Plugin Version 7 and above require namespace in build.gradle